### PR TITLE
add start option for vm creation

### DIFF
--- a/app/views/compute_resources_vms/form/proxmox/_general.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_general.html.erb
@@ -34,4 +34,7 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
       :label_size => "col-md-2" %>
     </div>
   <% end %>
+<!--TODO # Move to a helper-->
+  <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
+  <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2"} if new_vm && controller_name != "compute_attributes" %>
 <% end %>


### PR DESCRIPTION
adds the start option to vm creation. Copied from VMware compute resource: ./views/compute_resources_vms/form/vmware/_base.html.erb
