### PR TITLE
Do not use autogen ids for new volumes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,13 +14,13 @@ Metrics/AbcSize:
   Max: 60
 
 Metrics/BlockLength:
-  Max: 366
+  Max: 100
 
 Metrics/ClassLength:
   Max: 322
 
 Metrics/CyclomaticComplexity:
-  Max: 11
+  Max: 12
 
 Metrics/MethodLength:
   Max: 112
@@ -29,7 +29,7 @@ Metrics/ModuleLength:
   Max: 150
 
 Metrics/PerceivedComplexity:
-  Max: 11
+  Max: 12
 
 Metrics/LineLength:
   Max: 200 # TODO: discuss and set this

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,4 +1,10 @@
 
+Metrics/BlockLength:
+  Exclude:
+    - 'test/unit/foreman_fog_proxmox/proxmox_test.rb'
+    - 'test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb'
+    - 'test/unit/foreman_fog_proxmox/helpers/proxmox_server_helper_test.rb'
+
 Metrics/ClassLength:
   Exclude:
     - 'app/models/foreman_fog_proxmox/proxmox.rb'

--- a/app/models/foreman_fog_proxmox/proxmox.rb
+++ b/app/models/foreman_fog_proxmox/proxmox.rb
@@ -341,7 +341,7 @@ module ForemanFogProxmox
         id = volume_attributes['id']
         disk = vm.config.disks.get(id)
         delete = volume_attributes['_delete']
-        if disk
+        if disk && volume_attributes['volid'].present?
           if delete == '1'
             vm.detach(id)
             device = Fog::Proxmox::DiskHelper.extract_device(id)

--- a/test/unit/foreman_fog_proxmox/proxmox_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_test.rb
@@ -245,6 +245,7 @@ module ForemanFogProxmox
         config = mock('config')
         disks = mock('disks')
         disk = mock('disk')
+        disk.stubs(:volid).returns('local-lvm:vm-0815-disk-0')
         disk.stubs(:size).returns(1_073_741_824)
         disk.stubs(:storage).returns('local-lvm')
         disk.stubs(:id).returns('virtio0')
@@ -284,6 +285,7 @@ module ForemanFogProxmox
         config = mock('config')
         disks = mock('disks')
         disk = mock('disk')
+        disk.stubs(:volid).returns('local-lvm:vm-0815-disk-0')
         disk.stubs(:size).returns(1_073_741_824)
         disk.stubs(:storage).returns('local-lvm')
         disk.stubs(:id).returns('virtio0')
@@ -305,6 +307,7 @@ module ForemanFogProxmox
             '0' => {
               '_delete' => '1',
               'id' => 'scsi0',
+              'volid' => 'local-lvm:vm-0815-disk-0',
               'storage' => 'local-lvm',
               'size' => '2147483648',
               'cache' => 'none'
@@ -364,6 +367,7 @@ module ForemanFogProxmox
         config = mock('config')
         disks = mock('disks')
         disk = mock('disk')
+        disk.stubs(:volid).returns('local-lvm:vm-0815-disk-0')
         disk.stubs(:size).returns(1_073_741_824)
         disk.stubs(:storage).returns('local-lvm')
         disks.stubs(:get).returns(disk)
@@ -383,6 +387,7 @@ module ForemanFogProxmox
           'volumes_attributes' => {
             '0' => {
               'id' => 'scsi0',
+              'volid' => 'local-lvm:vm-0815-disk-0',
               'storage' => 'local-lvm',
               'size' => '2147483648',
               'cache' => 'none'
@@ -402,6 +407,7 @@ module ForemanFogProxmox
         config = mock('config')
         disks = mock('disks')
         disk = mock('disk')
+        disk.stubs(:volid).returns('local-lvm:vm-0815-disk-0')
         disk.stubs(:size).returns(1_073_741_824)
         disk.stubs(:storage).returns('local-lvm')
         disks.stubs(:get).returns(disk)
@@ -421,6 +427,7 @@ module ForemanFogProxmox
           'volumes_attributes' => {
             '0' => {
               'id' => 'scsi0',
+              'volid' => 'local-lvm:vm-0815-disk-0',
               'storage' => 'local-lvm',
               'size' => '2',
               'cache' => 'none'
@@ -441,6 +448,7 @@ module ForemanFogProxmox
         config = mock('config')
         disks = mock('disks')
         disk = mock('disk')
+        disk.stubs(:volid).returns('local-lvm:vm-0815-disk-0')
         disk.stubs(:size).returns(1_073_741_824)
         disk.stubs(:storage).returns('local-lvm')
         disks.stubs(:get).returns(disk)
@@ -460,6 +468,7 @@ module ForemanFogProxmox
           'volumes_attributes' => {
             '0' => {
               'id' => 'scsi0',
+              'volid' => 'local-lvm2:vm-0815-disk-0',
               'storage' => 'local-lvm2',
               'size' => '1073741824',
               'cache' => 'none'
@@ -545,6 +554,7 @@ module ForemanFogProxmox
         config = mock('config')
         disks = mock('disks')
         disk = mock('disk')
+        disk.stubs(:volid).returns('local-lvm:vm-0815-disk-0')
         disk.stubs(:size).returns(1_073_741_824)
         disk.stubs(:storage).returns('local-lvm')
         disk.stubs(:id).returns('rootfs')
@@ -566,6 +576,7 @@ module ForemanFogProxmox
             'volumes_attributes' => {
               '0' => {
                 'id' => 'rootfs',
+                'volid' => 'local-lvm:vm-0815-disk-0',
                 'storage' => 'local-lvm',
                 'size' => '2147483648',
                 'cache' => 'none'


### PR DESCRIPTION
Foreman fog proxmox always receives `id` `scsi0` for new volumes from foreman gui.
Even though the configured `controller` and `device` do not match this.
This resulted in additional-volumes not being created or wrong volumes being deleted.

Therefore, I needed to make foreman fog proxmox ignore this value for new volumes (volumes without a `volid`).