### PR TITLE
Fix column device-id

### DIFF
--- a/app/views/compute_resources_vms/form/proxmox/server/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/server/_volume.html.erb
@@ -22,7 +22,7 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
     <%= f.hidden_field :volid if !new_vm %>
     <%= select_f f, :storage, compute_resource.storages, :storage, :storage, { }, :label => _('Storage'), :label_size => "col-md-2" %>
     <%= select_f f, :controller, proxmox_controllers_map, :id, :name, { }, :label => _('Controller'), :label_size => "col-md-2", :disabled => !new_volume, :onchange => 'controllerSelected(this)' %>
-    <%= counter_f f, :device, :label => _('Device'), :label_size => "col-md-2", :disabled => !new_volume, :'data-soft-max' => proxmox_max_device(f.object.controller), :onchange => 'deviceSelected(this)' %>
+    <%= counter_f f, :device, :label => _('Device'), :label_size => "col-md-2", :disabled => !new_volume, :'data-min' => 0, :'data-soft-max' => proxmox_max_device(f.object.controller), :onchange => 'deviceSelected(this)' %>
     <%= select_f f, :cache, proxmox_caches_map, :id, :name, { }, :label => _('Cache'), :label_size => "col-md-2" %>
     <%= byte_size_f f, :size, :class => "input-mini", :label => _("Size"), :label_size => "col-md-2" %>
 <% end %>


### PR DESCRIPTION
Device ID 0 could not be selected with spinner-buttons.
Requires fix in foreman to support data-min field in counter_f input (https://github.com/theforeman/foreman/pull/7058)