### PR TITLE
Search for vm uuids on every cluster node

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/MethodLength:
   Max: 112
 
 Metrics/ModuleLength:
-  Max: 244
+  Max: 150
 
 Metrics/PerceivedComplexity:
   Max: 11

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,6 +9,10 @@ Metrics/LineLength:
     - 'app/models/foreman_fog_proxmox/proxmox.rb'
     - 'app/models/concerns/host_ext/proxmox/interfaces.rb'
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'test/unit/foreman_fog_proxmox/proxmox_test_helpers.rb'
+
 Naming/PredicateName:
   Exclude:
     - 'lib/foreman_fog_proxmox/semver.rb'

--- a/test/unit/foreman_fog_proxmox/proxmox_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_test.rb
@@ -72,6 +72,19 @@ module ForemanFogProxmox
           cr.find_vm_by_uuid('100')
         end
       end
+
+      it 'finds vm on other node in cluster' do
+        args = { vmid: '100', type: 'qemu' }
+        servers = mock('servers')
+        servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).with(args[:vmid]).returns(args)
+        cr = mock_cluster_nodes_servers_containers(
+          ForemanFogProxmox::Proxmox.new,
+          empty_servers, empty_servers, # node1
+          servers, empty_servers        # node2
+        )
+        assert_equal args, cr.find_vm_by_uuid(args[:vmid])
+      end
     end
 
     describe 'host_interfaces_attrs' do

--- a/test/unit/foreman_fog_proxmox/proxmox_test_helpers.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_test_helpers.rb
@@ -22,6 +22,7 @@ module ForemanFogProxmox
     def mock_node_servers(cr, servers)
       node = mock('node')
       node.stubs(:servers).returns(servers)
+      cr.stubs(:nodes).returns([node])
       cr.stubs(:node).returns(node)
       cr
     end
@@ -30,6 +31,7 @@ module ForemanFogProxmox
       node = mock('node')
       node.stubs(:containers).returns(containers)
       cr.stubs(:node).returns(node)
+      cr.stubs(:nodes).returns([node])
       cr
     end
 
@@ -38,6 +40,21 @@ module ForemanFogProxmox
       node.stubs(:containers).returns(containers)
       node.stubs(:servers).returns(servers)
       cr.stubs(:node).returns(node)
+      cr.stubs(:nodes).returns([node])
+      cr
+    end
+
+    def mock_cluster_nodes_servers_containers(cr, n1s, n1c, n2s, n2c)
+      node1 = mock('node')
+      node1.stubs(:node).returns('node1')
+      node1.stubs(:servers).returns(n1s)
+      node1.stubs(:containers).returns(n1c)
+      node2 = mock('node')
+      node2.stubs(:node).returns('node2')
+      node2.stubs(:servers).returns(n2s)
+      node2.stubs(:containers).returns(n2c)
+      cr.stubs(:node).returns(node1)
+      cr.stubs(:nodes).returns([node1, node2])
       cr
     end
 


### PR DESCRIPTION
This will make sure that VMs are found, even if they have been moved to a different cluster node.