### PR TITLE
fix "ActionView::Template::Error: undefined method `downcase' for XYZ:Integer"

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_images.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_images.rb
@@ -29,7 +29,7 @@ module ForemanFogProxmox
     end
 
     def available_images
-      templates.collect { |template| OpenStruct.new(id: template.vmid) }
+      templates.collect { |template| OpenStruct.new(id: template.vmid.to_s) }
     end
 
     def templates


### PR DESCRIPTION
Add .to_s to image_id in order to fix "ActionView::Template::Error: undefined method `downcase' for XYZ:Integer" caused by foreman images_helper.rb