### PR TITLE
Enable cluster node selection on create host.

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
@@ -145,7 +145,7 @@ module ForemanFogProxmox
       options = new_attr
       options = options.merge(node_id: node_id).merge(type: 'lxc').merge(vmid: next_vmid)
       options = vm_container_instance_defaults.merge(options) if new_attr.empty?
-      vm = node.containers.new(parse_container_vm(options).deep_symbolize_keys)
+      vm = (client.nodes.get args[:node_id]).containers.new(parse_container_vm(options).deep_symbolize_keys)
       logger.debug(format(_('new_container_vm() vm.config=%<config>s'), config: vm.config.inspect))
       vm
     end
@@ -154,7 +154,7 @@ module ForemanFogProxmox
       options = new_attr
       options = options.merge(node_id: node_id).merge(type: 'qemu').merge(vmid: next_vmid)
       options = vm_server_instance_defaults.merge(options) if new_attr.empty?
-      vm = node.servers.new(parse_server_vm(options).deep_symbolize_keys)
+      vm = (client.nodes.get args[:node_id]).servers.new(parse_server_vm(options).deep_symbolize_keys)
       logger.debug(format(_('new_server_vm() vm.config=%<config>s'), config: vm.config.inspect))
       vm
     end

--- a/app/views/compute_resources_vms/form/proxmox/_general.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_general.html.erb
@@ -20,7 +20,7 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
 <%= field_set_tag _("General"), :id => "general" do %>
   <%= checkbox_f f, :templated, :label => _('Create image?'), :disabled => untemplatable, :class => ('hide' if untemplatable), :no_label => untemplatable %>
   <%= counter_f f, :vmid, :label => _('VM ID'), :label_size => "col-md-2", :required => true, :disabled => (!new_vm || from_profile) %>
-  <%= select_f f, :node_id, compute_resource.nodes, :node, :node, { }, :label => _('Node'), :label_size => "col-md-2", :required => true, :disabled => true %>
+  <%= select_f f, :node_id, compute_resource.nodes, :node, :node, { }, :label => _('Node'), :label_size => "col-md-2", :required => true, :disabled => !new_vm %>
   <% unless local_assigns[:hide_image] && !new_vm %>
     <%
       arch ||= nil ; os ||= nil


### PR DESCRIPTION
When using a proxmox cluster configuration, this enables the possibility to choose the target cluster node on new host creation.