### PR TITLE
only start vm if it's not running.

### DIFF
--- a/app/models/concerns/fog_extensions/proxmox/server.rb
+++ b/app/models/concerns/fog_extensions/proxmox/server.rb
@@ -24,7 +24,7 @@ module FogExtensions
       attr_accessor :image_id, :templated, :ostemplate_storage, :ostemplate_file, :password
 
       def start
-        action('start')
+        ready? ? state : action('start')
       end
 
       def stop


### PR DESCRIPTION
only start the vm if it's not currently in running state. This prevents an exception if start is called twice.