### PR TITLE
Add start option for vm creation

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -21,12 +21,6 @@ module ForemanFogProxmox
   module ProxmoxVmCommands
     include ProxmoxVolumes
 
-    def start_on_boot(vm, args)
-      startonboot = args[:config_attributes][:onboot].blank? ? false : Foreman::Cast.to_bool(args[:config_attributes][:onboot])
-      vm.start if startonboot
-      vm
-    end
-
     def create_vm(args = {})
       vmid = args[:vmid].to_i
       type = args[:type]
@@ -46,7 +40,7 @@ module ForemanFogProxmox
           hash = hash.merge(vmid: vmid)
           vm = node.containers.create(hash.reject { |key, _value| ['ostemplate_storage', 'ostemplate_file'].include? key })
         end
-        start_on_boot(vm, args)
+        vm
       end
     rescue StandardError => e
       logger.warn(format(_('failed to create vm: %<e>s'), e: e))
@@ -100,7 +94,6 @@ module ForemanFogProxmox
         cdrom_attributes = parsed_attr.select { |_key, value| Fog::Proxmox::DiskHelper.cdrom?(value.to_s) }
         config_attributes = config_attributes.reject { |key, _value| Fog::Proxmox::DiskHelper.disk?(key) }
         vm.update(config_attributes.merge(cdrom_attributes))
-        start_on_boot(vm, new_attributes)
       end
       find_vm_by_uuid(uuid)
     end

--- a/app/views/compute_resources_vms/form/proxmox/server/_config.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/server/_config.html.erb
@@ -20,6 +20,18 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
 <% server = type == 'qemu' %>
 
 <%= field_set_tag n_("Main option", "Main options", 2), :id => "server_config_options", :class => 'hide', :disabled => !server do %>
+  <%= checkbox_f f, :start, {
+    :checked => !(
+      params &&
+      params[:host] &&
+      params[:host][:compute_attributes] &&
+      params[:host][:compute_attributes][:config_attributes] &&
+      params[:host][:compute_attributes][:config_attributes][:start] == '0'
+    ),
+    :help_inline => _("Power ON this machine"),
+    :label => _('Start'),
+    :label_size => "col-md-2"
+  } if new_vm && controller_name != "compute_attributes" %>
   <%= textarea_f f, :description, :label => _('Description'), :label_size => "col-md-2" %>
   <%= text_f f, :boot, :label => _('Boot device order'), :label_size => "col-md-2", :label_help => _('Floppy disk (a), hard disk (c), cdrom (d), network (n). Default cdn')  %>
   <%= checkbox_f f, :onboot, :label => _('Start at boot') %>


### PR DESCRIPTION
This was originally added in abac0e7f6548e734b0a41da034cf83299959444c but removed in 04f12cd89415cc7262533a86eb18a48088680ecc.

The latter does an implicit start of the vm, if it is created wit the `boot`-option.
IMHO these are separate options.

I would like to add this to the compute-profile as well, which seems a little tricky because it is an option that is only used on creation of the proxmox-vm.
Help wanted :wink: 