### PR TITLE
Fix for the CoreOS Family identifier

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_operating_systems.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_operating_systems.rb
@@ -39,7 +39,7 @@ module ForemanFogProxmox
     end
 
     def os_linux_types_mapping(host)
-      ['Debian', 'Redhat', 'Suse', 'Altlinux', 'Archlinux', 'CoreOs', 'Gentoo'].include?(host.operatingsystem.type) ? available_linux_operating_systems : []
+      ['Debian', 'Redhat', 'Suse', 'Altlinux', 'Archlinux', 'Coreos', 'Gentoo'].include?(host.operatingsystem.type) ? available_linux_operating_systems : []
     end
 
     def os_windows_types_mapping(host)

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -32,6 +32,10 @@ module ForemanFogProxmox
       vmid = args[:vmid].to_i
       type = args[:type]
       node = client.nodes.get(args[:node_id])
+      if vmid == 0
+        vmid = node.servers.next_id
+        args = args.merge(vmid: vmid)
+      end
       raise ::Foreman::Exception, format(N_('invalid vmid=%<vmid>s'), vmid: vmid) unless node.servers.id_valid?(vmid)
 
       image_id = args[:image_id]


### PR DESCRIPTION
Fix for the CoreOS Family identifier, because Foreman uses "Coreos" instead of "CoreOs". Fixes #158 