### PR TITLE
Update foreman_fog_proxmox_tasks.rake

### DIFF
--- a/lib/tasks/foreman_fog_proxmox_tasks.rake
+++ b/lib/tasks/foreman_fog_proxmox_tasks.rake
@@ -32,6 +32,3 @@ namespace :foreman_fog_proxmox do
 end
 
 Rake::Task[:test].enhance ['test:foreman_fog_proxmox']
-
-load 'tasks/jenkins.rake'
-Rake::Task['jenkins:unit'].enhance ['test:foreman_fog_proxmox', 'foreman_fog_proxmox:rubocop'] if Rake::Task.task_defined?(:'jenkins:unit')


### PR DESCRIPTION
Remove jenkins task to run rubocop because of https://github.com/theforeman/foreman_bootdisk/pull/90#issuecomment-696703527