### PR TITLE
Fix VM creation through API

### DIFF
--- a/app/models/concerns/orchestration/proxmox/compute.rb
+++ b/app/models/concerns/orchestration/proxmox/compute.rb
@@ -62,7 +62,7 @@ module Orchestration
       def computeValue(foreman_attr, fog_attr)
         value = ''
         value += compute_resource.id.to_s + '_' if foreman_attr == :uuid
-        value += vm.send(fog_attr)
+        value += vm.send(fog_attr).to_s
         value
       end
 


### PR DESCRIPTION
If you uses API and provides some attributes as integer, the #computeValue raise with an invalid implicit conversion of Integer into String

Fixes #215 