### PR TITLE
fix 500 when browsing VMs in compute resource (Integer to String)

### DIFF
--- a/app/models/concerns/fog_extensions/proxmox/server.rb
+++ b/app/models/concerns/fog_extensions/proxmox/server.rb
@@ -24,7 +24,7 @@ module FogExtensions
       attr_accessor :image_id, :templated, :ostemplate_storage, :ostemplate_file, :password, :start_after_create
 
       def unique_cluster_identity(compute_resource)
-        compute_resource.id.to_s + '_' + identity
+        compute_resource.id.to_s + '_' + identity.to_s
       end
 
       def start


### PR DESCRIPTION
on Foreman 3.0.1, proxmox VE 7.0-11

Here is the error:
```
Backtrace for 'no implicit conversion of Integer into String' error (ActionView::Template::Error): no implicit conversion of Integer into String
/usr/share/foreman/vendor/ruby/2.5.0/gems/foreman_fog_proxmox-0.14.0/app/models/concerns/fog_extensions/proxmox/server.rb:27:in `+'
/usr/share/foreman/vendor/ruby/2.5.0/gems/foreman_fog_proxmox-0.14.0/app/models/concerns/fog_extensions/proxmox/server.rb:27:in `unique_cluster_identity'
/usr/share/foreman/vendor/ruby/2.5.0/gems/foreman_fog_proxmox-0.14.0/app/views/compute_resources_vms/index/_proxmox.html.erb:34:in `block in _94910306308b1e629dd9be22f5198ab2'
/usr/share/foreman/vendor/ruby/2.5.0/gems/foreman_fog_proxmox-0.14.0/app/views/compute_resources_vms/index/_proxmox.html.erb:32:in `each'
/usr/share/foreman/vendor/ruby/2.5.0/gems/foreman_fog_proxmox-0.14.0/app/views/compute_resources_vms/index/_proxmox.html.erb:32:in `_94910306308b1e629dd9be22f5198ab2'
/usr/share/foreman/vendor/ruby/2.5.0/gems/actionview-6.0.3.7/lib/action_view/base.rb:274:in `_run'
```