### PR TITLE
link hosts and vms by lower case MAC + fix 500

### DIFF
--- a/app/models/concerns/host_ext/proxmox/for_vm.rb
+++ b/app/models/concerns/host_ext/proxmox/for_vm.rb
@@ -24,7 +24,7 @@ module HostExt
       module ClassMethods
         def for_vm_uuid(cr, vm)
           uuid = vm&.identity
-          uuid = cr.id.to_s + '_' + vm&.identity if cr.class == ForemanFogProxmox::Proxmox
+          uuid = cr.id.to_s + '_' + vm&.identity.to_s if cr.class == ForemanFogProxmox::Proxmox
           where(:compute_resource_id => cr.id, :uuid => uuid)
         end
       end

--- a/app/models/foreman_fog_proxmox/proxmox.rb
+++ b/app/models/foreman_fog_proxmox/proxmox.rb
@@ -65,7 +65,7 @@ module ForemanFogProxmox
     end
 
     def associate_by(name, attributes)
-      Host.authorized(:view_hosts, Host).joins(:primary_interface).where(:nics => { :primary => true }).where("nics.#{name}" => attributes).readonly(false).first
+      Host.authorized(:view_hosts, Host).joins(:primary_interface).where(:nics => { :primary => true }).where("nics.#{name}".downcase => attributes.downcase).readonly(false).first
     end
 
     def ssl_certs


### PR DESCRIPTION
Proxmox 7.1-10
Lastest fog_proxmox
Latest stable foreman: 3.1.2

I've found the following problem while linking an existing host to a VM

The puppet facts store the MAC in lower case.

The proxmox compute resource (this plugin) pulls the MAC in upper case from the Proxmox API (or Proxmox provides it in upper case) 

Therefore, it is not possible to link an existing host with a proxmox host. (Since the comparison is case-sensitive)

The attached commit converts both values to lower case before attempting to associate the different objects. (Works again)

Furthermore, d30e1c435c2d456b9519bc74b407f6aa89a256e2 converts the identity (int) to a string to fix a 500 when clicking on the “Associate VMs” button. Similar to #220 