### PR TITLE
ci(coverage): fixes prefix codeclimate report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         GIT_BRANCH: ${{ github.ref }}
         GIT_COMMIT_SHA: ${{ github.sha }}
       with:
-        workingDirectory: foreman_fog_proxmox/coverage
+        workingDirectory: ${{github.workspace}}/foreman_fog_proxmox
         debug: true
         coverageLocations: |
           ${{github.workspace}}/foreman_fog_proxmox/coverage/coverage.json:simplecov


### PR DESCRIPTION
```json
{
  "message": "Invalid path part \"/\"",
  "file_document": "{\"_id\"=>BSON::ObjectId('639226caa40b9629350061fa'), \"type\"=>\"test_file_reports\", \"blob_id\"=>\"4509972d76671fe8d740f567117c8854a76f7be5\", \"coverage\"=>\"[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,1,1,0,null,null,null,1,0,null,null,null,1,0,null,null,null,null,null,null,null,null,null,null,1,0,null,null,null,null,null,null,null,null,null,null,null,null,null,1,0,null,null,null,null,null,null,null,null,null,null,null,1,0,null,null,1,0,0,null,null,1,0,null,null,null,null,null,null,1,0,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,1,0,null,null,null,null,1,0,null,null,null,null,null,null,null,1,0,null,null,null,null,null,1,0,null,null,null]\", \"covered_percent\"=>50, \"covered_strength\"=>0.5, \"line_counts\"=>{\"missed\"=>14, \"covered\"=>14, \"total\"=>28}, \"path\"=>\"/home/runner/work/foreman_fog_proxmox/foreman_fog_proxmox/foreman_fog_proxmox/app/helpers/proxmox_compute_selectors_helper.rb\", \"test_report_id\"=>BSON::ObjectId('639226caddfa1d25a70078b4')}"
}
```

