### PR TITLE
Each host has it's own VNC port

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_console.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_console.rb
@@ -31,7 +31,9 @@ module ForemanFogProxmox
       options.store(:websocket, 1) if type_console == 'vnc'
       begin
         vnc_console = vm.start_console(options)
-        WsProxy.start(:host => host, :host_port => vnc_console['port'], :password => vnc_console['ticket']).merge(
+        vmid = extract_vmid(uuid).to_i
+        vnc_host_port = vnc_console['port'].to_i + vmid
+        WsProxy.start(:host => host, :host_port => vnc_host_port, :password => vnc_console['ticket']).merge(
           :name => vm.name, :type => type_console
         )
       rescue StandardError => e


### PR DESCRIPTION
As documented in https://pve.proxmox.com/wiki/VNC_Client_Access the VNC port of the host should then be: 5900 + vmid (Display number).