### PR TITLE
added taking over incomplete volume parameters

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -45,7 +45,7 @@ module ForemanFogProxmox
         update_pool(vm, args[:pool]) if args[:pool]
       else
         logger.warn("create vm: args=#{args}")
-        vm = node.send(vm_collection(type)).create(parse_typed_vm(args, type))
+        vm = node.send(vm_collection(type)).create(parse_typed_vm(update_extra_volumes_definitions(args), type))
       end
       start_on_boot(vm, args)
     rescue StandardError => e

--- a/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
@@ -161,7 +161,7 @@ module ForemanFogProxmox
     end
 
     def new_vm(new_attr = {})
-      new_attr = ActiveSupport::HashWithIndifferentAccess.new(new_attr)
+      new_attr = ActiveSupport::HashWithIndifferentAccess.new(update_extra_volumes_definitions(new_attr))
       type = new_attr['type']
       type ||= 'qemu'
       new_typed_vm(new_attr, type)


### PR DESCRIPTION
Hi,
I found out that when a new VM is to be created with a request for disks that are not in the ComputeProfile but simply added for example like this ( through hammer ) with: --volume='size=10GB' --volume='size=20GB' the disks do not show up properly in the json.

They show up like this:
"volumes_attributes"=>{
"0"=>{"storage_type"=>"hard_disk", "storage"=>"local-lvm", "controller"=>"virtio", "device"=>"0", "cache"=>"none", "size"=>"19GB", "id"=>"virtio0"}, 
"1"=>{"size"=>"10GB"}, 
"2"=>{"size"=>"20GB"}}, 

As an result disk 1 && 2 are disregarded and only the disk that has been mentioned in the ComputeProfile will get the size requested.

This patch adjusts the json to "copy" the settings from the first disk, into the next ones.

I Hope, you can consider this patch.
Thank you and regards,
Kees

