### PR TITLE
feat: filter inactive/disabled storages from GUI dropdowns

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_images.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_images.rb
@@ -28,7 +28,12 @@ module ForemanFogProxmox
       node ||= default_node
       storage = node.storages.get storage_id if storage_id
       logger.debug("images_by_storage(): node_id #{node_id} storage_id #{storage_id} type #{type}")
-      storage.volumes.list_by_content_type(type).sort_by(&:volid) if storage
+      return [] unless storage && storage_active?(storage)
+
+      storage.volumes.list_by_content_type(type).sort_by(&:volid)
+    rescue StandardError => e
+      logger.error("images_by_storage(): failed to list volumes for storage #{storage_id} on node #{node_id}: #{e.class}: #{e.message}")
+      []
     end
 
     def template_name(template)
@@ -48,9 +53,9 @@ module ForemanFogProxmox
       volumes = []
       nodes.each do |node|
         storages(node.node).each do |storage|
-          # Skip disabled storages (enabled == 0 or nil)
-          unless storage.enabled.to_i == 1
-            logger.warn("Skipping disabled storage #{storage.identity} on #{node.node}")
+          # Skip inactive or disabled storages
+          unless storage_active?(storage)
+            logger.warn("Skipping inactive/disabled storage #{storage.identity} on #{node.node}")
             next
           end
 

--- a/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
@@ -25,18 +25,17 @@ require 'foreman_fog_proxmox/hash_collection'
 module ForemanFogProxmox
   module ProxmoxVMNew
     include ProxmoxVMHelper
-
     def cdrom_defaults
       { storage_type: 'cdrom', id: 'ide2', volid: 'none', media: 'cdrom' }
     end
 
     def cloudinit_defaults
-      { storage_type: 'cloud_init', id: 'ide0', storage: storages.first.identity.to_s, media: 'cdrom' }
+      { storage_type: 'cloud_init', id: 'ide0', storage: default_storage_id, media: 'cdrom' }
     end
 
     def hard_disk_typed_defaults(vm_type)
       options = {}
-      volume_attributes_h = { storage: storages.first.identity.to_s, size: '8' }
+      volume_attributes_h = { storage: default_storage_id, size: '8' }
       case vm_type
       when 'qemu'
         controller = 'virtio'
@@ -69,18 +68,18 @@ module ForemanFogProxmox
     end
 
     def interface_defaults(id = 'net0')
-      { id: id, compute_attributes: { model: 'virtio', name: 'eth0', bridge: bridges.first.identity.to_s } }
+      { id: id, compute_attributes: { model: 'virtio', name: 'eth0', bridge: default_bridge_id } }
     end
 
     def interface_typed_defaults(type)
       interface_attributes_h = { id: 'net0', compute_attributes: {} }
       if type == 'qemu'
         interface_attributes_h[:compute_attributes] =
-          { model: 'virtio', bridge: bridges.first.identity.to_s }
+          { model: 'virtio', bridge: default_bridge_id }
       end
       if type == 'lxc'
         interface_attributes_h[:compute_attributes] =
-          { name: 'eth0', bridge: bridges.first.identity.to_s, dhcp: 1, dhcp6: 1 }
+          { name: 'eth0', bridge: default_bridge_id, dhcp: 1, dhcp6: 1 }
       end
       interface_attributes_h
     end

--- a/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
@@ -32,7 +32,65 @@ module ForemanFogProxmox
       node ||= default_node
       storages = node.storages.list_by_content_type type
       logger.debug("storages(): node_id #{node_id} type #{type}")
-      storages.sort_by(&:storage)
+      storages.select { |s| storage_active?(s) }.sort_by(&:storage)
+    rescue StandardError => e
+      logger.error("storages(): failed to list storages on node #{node_id}: #{e.class}: #{e.message}")
+      []
+    end
+
+    def storage_active?(storage)
+      # Default to true when attributes are missing - older Proxmox API versions
+      # may not expose :active/:enabled, and we treat unknown state as usable.
+      active = storage.respond_to?(:active) ? storage.active.to_i == 1 : true
+      enabled = storage.respond_to?(:enabled) ? storage.enabled.to_i == 1 : true
+      unless active && enabled
+        active_val = storage.respond_to?(:active) ? storage.active : 'N/A'
+        enabled_val = storage.respond_to?(:enabled) ? storage.enabled : 'N/A'
+        logger.debug("Filtering out inactive/disabled storage #{storage.storage} " \
+                      "(active=#{active_val}, enabled=#{enabled_val})")
+      end
+      active && enabled
+    end
+
+    def storage_for_node(node_id)
+      storage_mapping = attrs.fetch(:storage_mapping, {})
+      mapped = storage_mapping[node_id]
+      if mapped
+        # Verify mapped storage is actually active on the node
+        available = storages(node_id)
+        if available.any? { |s| s.storage == mapped }
+          logger.info("storage_for_node(): using mapped storage '#{mapped}' for node '#{node_id}'")
+          return mapped
+        end
+        logger.warn("storage_for_node(): mapped storage '#{mapped}' not active on node '#{node_id}', falling back to auto-select")
+      end
+
+      # Auto-select first available storage on the node
+      available = storages(node_id)
+      if available.any?
+        selected = available.first&.storage
+        logger.info("storage_for_node(): auto-selected storage '#{selected}' for node '#{node_id}'")
+        selected
+      else
+        default = attrs[:storage]
+        logger.warn("storage_for_node(): no active storage found on node '#{node_id}', falling back to '#{default}'")
+        default
+      end
+    end
+
+    def default_storage_id
+      storage_for_node(default_node_id)
+    rescue StandardError => e
+      logger.warn("default_storage_id(): failed to resolve storage: #{e.message}")
+      nil
+    end
+
+    def default_bridge_id
+      br = bridges.first
+      br ? br.identity.to_s : nil
+    rescue StandardError => e
+      logger.warn("default_bridge_id(): failed to resolve bridge: #{e.message}")
+      nil
     end
 
     def bridges(node_id = default_node_id)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_queries_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_queries_test.rb
@@ -64,5 +64,117 @@ module ForemanFogProxmox
         assert_equal vm, cr.find_vm_by_uuid('1_' + args[:vmid])
       end
     end
+
+    describe 'storage_active?' do
+      before do
+        @cr = ForemanFogProxmox::Proxmox.new
+        @cr.stubs(:logger).returns(stub_everything('logger'))
+      end
+
+      it 'returns true when storage is active and enabled' do
+        storage = mock('storage')
+        storage.stubs(:respond_to?).with(:active).returns(true)
+        storage.stubs(:respond_to?).with(:enabled).returns(true)
+        storage.stubs(:active).returns(1)
+        storage.stubs(:enabled).returns(1)
+        storage.stubs(:storage).returns('local-lvm')
+        assert @cr.send(:storage_active?, storage)
+      end
+
+      it 'returns false when storage is inactive' do
+        storage = mock('storage')
+        storage.stubs(:respond_to?).with(:active).returns(true)
+        storage.stubs(:respond_to?).with(:enabled).returns(true)
+        storage.stubs(:active).returns(0)
+        storage.stubs(:enabled).returns(1)
+        storage.stubs(:storage).returns('local-lvm')
+        assert_not @cr.send(:storage_active?, storage)
+      end
+
+      it 'returns false when storage is disabled' do
+        storage = mock('storage')
+        storage.stubs(:respond_to?).with(:active).returns(true)
+        storage.stubs(:respond_to?).with(:enabled).returns(true)
+        storage.stubs(:active).returns(1)
+        storage.stubs(:enabled).returns(0)
+        storage.stubs(:storage).returns('local-lvm')
+        assert_not @cr.send(:storage_active?, storage)
+      end
+
+      it 'defaults to true when attributes are missing (older API)' do
+        storage = mock('storage')
+        storage.stubs(:respond_to?).with(:active).returns(false)
+        storage.stubs(:respond_to?).with(:enabled).returns(false)
+        storage.stubs(:storage).returns('ceph-pool')
+        assert @cr.send(:storage_active?, storage)
+      end
+    end
+
+    describe 'storages' do
+      it 'filters out inactive storages' do
+        active_storage = mock('active_storage')
+        active_storage.stubs(:respond_to?).returns(true)
+        active_storage.stubs(:active).returns(1)
+        active_storage.stubs(:enabled).returns(1)
+        active_storage.stubs(:storage).returns('ceph')
+
+        inactive_storage = mock('inactive_storage')
+        inactive_storage.stubs(:respond_to?).returns(true)
+        inactive_storage.stubs(:active).returns(0)
+        inactive_storage.stubs(:enabled).returns(1)
+        inactive_storage.stubs(:storage).returns('local-lvm')
+
+        storages_list = mock('storages_list')
+        storages_list.stubs(:list_by_content_type).returns([active_storage, inactive_storage])
+
+        node = mock('node')
+        node.stubs(:node).returns('pve')
+        node.stubs(:storages).returns(storages_list)
+
+        nodes_collection = mock('nodes_collection')
+        nodes_collection.stubs(:get).with('pve').returns(node)
+
+        client = mock('client')
+        client.stubs(:nodes).returns(nodes_collection)
+
+        cr = ForemanFogProxmox::Proxmox.new
+        cr.stubs(:logger).returns(stub_everything('logger'))
+        cr.stubs(:client).returns(client)
+        cr.stubs(:default_node).returns(node)
+
+        result = cr.storages('pve')
+        assert_equal ['ceph'], result.map(&:storage)
+      end
+
+      it 'returns empty array on error' do
+        cr = ForemanFogProxmox::Proxmox.new
+        cr.stubs(:logger).returns(stub_everything('logger'))
+        cr.stubs(:client).raises(StandardError, 'connection refused')
+
+        result = cr.storages('pve')
+        assert_empty result
+      end
+    end
+
+    describe 'default_bridge_id' do
+      it 'returns first bridge identity' do
+        bridge = mock('bridge')
+        bridge.stubs(:identity).returns('vmbr0')
+
+        cr = ForemanFogProxmox::Proxmox.new
+        cr.stubs(:logger).returns(stub_everything('logger'))
+        cr.stubs(:bridges).returns([bridge])
+
+        assert_equal 'vmbr0', cr.send(:default_bridge_id)
+      end
+
+      it 'returns nil when no bridges available' do
+        cr = ForemanFogProxmox::Proxmox.new
+        cr.stubs(:logger).returns(stub_everything('logger'))
+        cr.stubs(:bridges).returns([])
+
+        assert_nil cr.send(:default_bridge_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #457

When a Proxmox node doesn't have a particular storage (e.g. `local-lvm`) but has other backends like CEPH, the GUI storage dropdowns still showed all storages regardless of their active/enabled state. This caused confusion and errors when users selected a non-existent storage.

## Changes

### `proxmox_vm_queries.rb`
- **`storages()`** now filters results through `storage_active?()` — GUI dropdowns only show storages that are actually active and enabled on the selected node
- **`storage_active?()`** — new helper checking both Proxmox API `active` and `enabled` attributes with safe `respond_to?` guards
- **`storage_for_node()`** — new method for per-node storage mapping via `attrs[:storage_mapping]` with auto-selection fallback

### `proxmox_images.rb`
- **`images_by_storage()`** — checks `storage_active?` before listing volumes, returns `[]` with error handling instead of raising exceptions
- **`templates()`** — uses consistent `storage_active?()` instead of manual `enabled` check

## GUI impact

All storage dropdowns are populated via `storages(node_id)` — both from ERB templates (`select_f`) and via AJAX calls (`nodeSelected()` JS → `/foreman_fog_proxmox/storages/:cr_id/:node_id`). The filtering is transparent to the GUI.

## Testing

Backward compatible — setups where all storages are active see no change.