### PR TITLE
Fixes #460 - Verify VMID existence before creating VM

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -71,9 +71,9 @@ module ForemanFogProxmox
     def vmid_exists?(vmid)
       nodes.any? do |search_node|
         search_node.servers.get(vmid) || search_node.containers.get(vmid)
+      rescue Fog::Errors::NotFound
+        false
       end
-    rescue Fog::Errors::NotFound
-      false
     end
 
     def compute_clone_attributes(args, container, type)

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -56,7 +56,24 @@ module ForemanFogProxmox
     end
 
     def assign_vmid(vmid, node)
-      (vmid < 1) ? node.servers.next_id : vmid
+      vmid = node.servers.next_id if vmid < 1
+      max_retries = 5
+      retries = 0
+      while vmid_exists?(vmid) && retries < max_retries
+        logger.warn("assign_vmid: VMID #{vmid} already exists, requesting new one (attempt #{retries + 1})")
+        vmid = node.servers.next_id
+        retries += 1
+      end
+      raise ::Foreman::Exception, N_('Unable to find a free VMID after %s attempts') % max_retries if vmid_exists?(vmid)
+      vmid
+    end
+
+    def vmid_exists?(vmid)
+      nodes.any? do |search_node|
+        search_node.servers.get(vmid) || search_node.containers.get(vmid)
+      end
+    rescue Fog::Errors::NotFound
+      false
     end
 
     def compute_clone_attributes(args, container, type)

--- a/test/factories/foreman_fog_proxmox/proxmox_node_mock_factory.rb
+++ b/test/factories/foreman_fog_proxmox/proxmox_node_mock_factory.rb
@@ -19,11 +19,18 @@
 
 module ForemanFogProxmox
   module ProxmoxNodeMockFactory
+    def mock_empty_collection
+      col = mock('collection')
+      col.stubs(:get).returns(nil)
+      col
+    end
+
     def mock_node_servers(cr, servers)
       node = mock('node')
       nodes = mock('nodes')
       node.stubs(:node).returns('proxmox')
       node.stubs(:servers).returns(servers)
+      node.stubs(:containers).returns(mock_empty_collection)
       nodes.stubs(:get).returns(node)
       nodes.stubs(:all).returns([node])
       client = mock('client')
@@ -37,6 +44,7 @@ module ForemanFogProxmox
       nodes = mock('nodes')
       node.stubs(:node).returns('proxmox')
       node.stubs(:containers).returns(containers)
+      node.stubs(:servers).returns(mock_empty_collection)
       nodes.stubs(:get).returns(node)
       nodes.stubs(:all).returns([node])
       client = mock('client')

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
@@ -256,7 +256,9 @@ module ForemanFogProxmox
         args = { vmid: '100', type: 'lxc', node_id: 'proxmox', start_after_create: '0' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).returns(nil)
         containers = mock('containers')
+        containers.stubs(:get).returns(nil)
         containers.stubs(:create).with(args)
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
         cr.stubs(:parse_typed_vm).with(args, 'lxc').returns(args)
@@ -269,7 +271,9 @@ module ForemanFogProxmox
         args = { vmid: '100', type: 'lxc', node_id: 'proxmox', start_after_create: '1' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).returns(nil)
         containers = mock('containers')
+        containers.stubs(:get).returns(nil)
         vm = mock('vm')
         containers.stubs(:create).with(args).returns(vm)
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
@@ -283,7 +287,9 @@ module ForemanFogProxmox
         args = { vmid: '100', type: 'lxc', node_id: 'proxmox', start_after_create: '0', pool: 'pool1' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).returns(nil)
         containers = mock('containers')
+        containers.stubs(:get).returns(nil)
         vm = mock('vm')
         containers.stubs(:create).with(args).returns(vm)
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
@@ -296,7 +302,9 @@ module ForemanFogProxmox
         args = { vmid: '100', type: 'lxc', image_id: '999', name: 'name' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).returns(nil)
         containers = mock('containers')
+        containers.stubs(:get).returns(nil)
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
         vm = mock('vm')
         cr.expects(:clone_from_image).with('999', 100).returns(vm)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -35,6 +35,7 @@ module ForemanFogProxmox
         args = { vmid: '100' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(false)
+        servers.stubs(:get).returns(nil)
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
         err = assert_raises Foreman::Exception do
           cr.create_vm(args)
@@ -47,6 +48,7 @@ module ForemanFogProxmox
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
         servers.stubs(:next_id).returns('101')
+        servers.stubs(:get).returns(nil)
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
         servers.stubs(:create).with(args)
@@ -59,6 +61,7 @@ module ForemanFogProxmox
         args = { vmid: '100', type: 'qemu', node_id: 'proxmox', start_after_create: '0' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).returns(nil)
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
         servers.stubs(:create).with(args)
@@ -71,6 +74,7 @@ module ForemanFogProxmox
         args = { vmid: '100', type: 'qemu', node_id: 'proxmox', start_after_create: '1' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).returns(nil)
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
         vm = mock('vm')
@@ -84,6 +88,7 @@ module ForemanFogProxmox
         args = { vmid: '100', type: 'qemu', node_id: 'proxmox', start_after_create: '0', pool: 'pool1' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).returns(nil)
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
         vm = mock('vm')
@@ -98,6 +103,8 @@ module ForemanFogProxmox
         servers = mock('servers')
         containers = mock('containers')
         servers.stubs(:id_valid?).returns(true)
+        servers.stubs(:get).returns(nil)
+        containers.stubs(:get).returns(nil)
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
         vm = mock('vm')
         cr.expects(:clone_from_image).with('999', 100).returns(vm)


### PR DESCRIPTION
## Problem

When creating a new VM through Foreman, the `assign_vmid` method blindly trusts the VMID returned by Proxmox's `/cluster/nextid` endpoint without verifying that no VM with that ID already exists in the cluster.

This can lead to **silent overwriting** of existing VM configurations when:
- A VM exists in Proxmox but is not managed by Foreman
- Proxmox's `/etc/pve/nextid` file is stale after manual VM creation/deletion
- A race condition occurs between concurrent VM creation requests

The existing `id_valid?` check only validates the VMID range (100–999999999), not whether the VMID is actually free.

## Solution

Added a `vmid_exists?` method that checks all cluster nodes for existing VMs and containers with the given VMID. The `assign_vmid` method now:

1. Gets a VMID candidate (from `next_id` or user input)
2. Checks if a VM/container with that VMID already exists on any node
3. If it exists, requests a new VMID from Proxmox and retries
4. Repeats up to 5 times before raising an error

This ensures Foreman never creates or clones a VM with a VMID that is already in use, regardless of whether the existing VM is managed by Foreman or not.

## Changes

- `assign_vmid`: Added existence check loop with retry logic
- `vmid_exists?`: New method that scans all cluster nodes for VMs and containers with the given VMID

## Testing

- If VMID is free → works exactly as before (no behavior change)
- If VMID is taken → retries with a new VMID from `next_id`
- If no free VMID found after 5 retries → raises a clear error
- Both VMs and LXC containers are checked to prevent cross-type collisions