### PR TITLE
Fix boot disk for image-based provisioning

### DIFF
--- a/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
+++ b/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
@@ -101,6 +101,7 @@ module ForemanFogProxmox
         pools: extract_pools(cr),
         storages: extract_storages(cr),
         bridges: extract_bridges(cr),
+        images: extract_images(cr),
       }
     end
 
@@ -139,6 +140,39 @@ module ForemanFogProxmox
           iface: (h[:iface] || h['iface']),
         }
       end
+    end
+
+    def extract_images(compute_resource)
+      images = compute_resource.images
+      images = images.order(:name) if images.respond_to?(:order)
+
+      Array(images).map do |image|
+        data = image.respond_to?(:as_json) ? image.as_json : image
+        uuid = image_value(image, data, :uuid, :id)
+
+        {
+          uuid: uuid,
+          name: image_value(image, data, :name),
+          disks: image_disks(compute_resource, uuid),
+        }
+      end
+    end
+
+    def image_disks(compute_resource, uuid)
+      return nil unless uuid && compute_resource.respond_to?(:find_vm_by_uuid)
+
+      compute_resource.find_vm_by_uuid(uuid)&.disks
+    rescue ActiveRecord::RecordNotFound, StandardError
+      nil
+    end
+
+    def image_value(image, data, *keys)
+      keys.each do |key|
+        value = [image.try(key), data.try(:[], key), data.try(:[], key.to_s)].find(&:present?)
+        return value if value.present?
+      end
+
+      nil
     end
 
     def load_compute_resource(compute_resource_id)

--- a/webpack/components/ProxmoxServer/ProxmoxServerStorage.js
+++ b/webpack/components/ProxmoxServer/ProxmoxServerStorage.js
@@ -9,6 +9,9 @@ import {
   Spinner,
   Bullseye,
   Divider,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
@@ -28,6 +31,8 @@ const ProxmoxServerStorage = ({
   isLoading,
   computeResourceId,
   isTabActive,
+  selectedImage,
+  provisionMethodState,
 }) => {
   const bootDiskId = React.useMemo(() => {
     if (!bootOrder) return null;
@@ -39,6 +44,27 @@ const ProxmoxServerStorage = ({
       .filter(Boolean);
     return entries.find(entry => !entry.startsWith('net')) || null;
   }, [bootOrder]);
+
+  const templateDiskSlots = React.useMemo(() => {
+    const slots = new Set();
+    if (provisionMethodState !== 'image') return slots;
+    const disks = selectedImage?.disks;
+    if (!Array.isArray(disks)) return slots;
+    disks.forEach(diskEntry => {
+      if (diskEntry.includes('media=cdrom')) return;
+      const match = diskEntry.match(/^([a-z]+)(\d+):/i);
+      if (!match) return;
+      const [, rawController, deviceStr] = match;
+      const controller = rawController.toLowerCase();
+      const device = parseInt(deviceStr, 10);
+      if (Number.isNaN(device)) return;
+      slots.add(`${controller}${device}`);
+    });
+
+    return slots;
+  }, [provisionMethodState, selectedImage]);
+
+  const templateDiskSlotList = Array.from(templateDiskSlots).sort();
 
   const [hardDisks, setHardDisks] = useState([]);
   const [nextId, setNextId] = useState(0);
@@ -99,11 +125,13 @@ const ProxmoxServerStorage = ({
         i++
       ) {
         if (!(isDevice2Reserved && i === 2)) {
+          const slotId = `${controller}${i}`;
           if (
+            !templateDiskSlots.has(slotId) &&
             !hardDisks.some(
               disk =>
                 disk.data.controller.value === controller &&
-                disk.data.device.value === i
+                parseInt(disk.data.device.value, 10) === i
             )
           ) {
             return i;
@@ -112,7 +140,7 @@ const ProxmoxServerStorage = ({
       }
       return null;
     },
-    [hardDisks, controllerRanges]
+    [hardDisks, controllerRanges, templateDiskSlots]
   );
 
   const createUniqueDevice = useCallback(
@@ -134,6 +162,51 @@ const ProxmoxServerStorage = ({
       return null;
     },
     [getNextDevice]
+  );
+
+  const validateHardDiskDevice = useCallback(
+    (controller, device, currentDiskId) => {
+      const range = controllerRanges[controller];
+      if (!range) {
+        return __('Invalid device value.');
+      }
+
+      if (!/^\d+$/.test(String(device))) {
+        return __('Invalid device value.');
+      }
+
+      const parsedDevice = parseInt(device, 10);
+
+      if (parsedDevice < range.min || parsedDevice > range.max) {
+        return sprintf(
+          __('Device must be between %(min)s and %(max)s for %(controller)s.'),
+          { min: range.min, max: range.max, controller }
+        );
+      }
+
+      if (controller === 'ide' && parsedDevice === 2) {
+        return __('Device ide2 is reserved for CD-ROM.');
+      }
+
+      if (templateDiskSlots.has(`${controller}${parsedDevice}`)) {
+        return __('This device is reserved by the selected image template.');
+      }
+
+      if (
+        hardDisks.some(
+          disk =>
+            disk.id !== currentDiskId &&
+            !disk.hidden &&
+            disk.data.controller.value === controller &&
+            parseInt(disk.data.device.value, 10) === parsedDevice
+        )
+      ) {
+        return __('This device is already in use.');
+      }
+
+      return null;
+    },
+    [controllerRanges, hardDisks, templateDiskSlots]
   );
 
   const addHardDisk = useCallback(
@@ -342,6 +415,22 @@ const ProxmoxServerStorage = ({
         >
           {__('Add Efi Disk')}
         </Button>
+        {templateDiskSlotList.length > 0 && (
+          <FormHelperText>
+            <HelperText id="helper-template-reserved-slots">
+              <HelperTextItem
+                variant="warning"
+                style={{ fontSize: '1rem', fontWeight: 350, lineHeight: 1.5 }}
+              >
+                {`${
+                  templateDiskSlotList.length === 1
+                    ? __('Image template reserved slot')
+                    : __('Image template reserved slots')
+                }: ${templateDiskSlotList.join(', ')}`}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
         {cdRom && cdRomData && (
           <CDRom
             onRemove={removeCDRom}
@@ -421,6 +510,7 @@ const ProxmoxServerStorage = ({
                 fromProfile={fromProfile}
                 updateHardDiskData={updateHardDiskData}
                 createUniqueDevice={createUniqueDevice}
+                validateDevice={validateHardDiskDevice}
                 hidden={!!hardDisk.hidden}
                 isNew={!!hardDisk.isNew}
                 isPersistedDisk={isPersistedDisk}
@@ -445,6 +535,8 @@ ProxmoxServerStorage.propTypes = {
   isLoading: PropTypes.bool,
   computeResourceId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   isTabActive: PropTypes.bool,
+  selectedImage: PropTypes.object,
+  provisionMethodState: PropTypes.string,
 };
 
 ProxmoxServerStorage.defaultProps = {
@@ -459,6 +551,8 @@ ProxmoxServerStorage.defaultProps = {
   isLoading: false,
   computeResourceId: null,
   isTabActive: false,
+  selectedImage: null,
+  provisionMethodState: '',
 };
 
 export default ProxmoxServerStorage;

--- a/webpack/components/ProxmoxServer/components/HardDisk.js
+++ b/webpack/components/ProxmoxServer/components/HardDisk.js
@@ -12,24 +12,39 @@ const HardDisk = ({
   storages,
   updateHardDiskData,
   createUniqueDevice,
+  validateDevice,
   hidden,
   nodeId,
   fromProfile,
   isNew,
   isPersistedDisk,
 }) => {
-  const [hdd, setHdd] = useState(data);
-  const [error, setError] = useState(null);
+  const normalizeDeviceValue = value =>
+    value === null || value === undefined ? '' : String(value);
+
+  const [hdd, setHdd] = useState(() =>
+    data?.device
+      ? {
+          ...data,
+          device: {
+            ...data.device,
+            value: normalizeDeviceValue(data.device.value),
+          },
+        }
+      : data
+  );
+  const [controllerError, setControllerError] = useState(null);
+  const [deviceError, setDeviceError] = useState(null);
   const storagesMap = createStoragesMap(storages, null, nodeId);
   const lockController = isPersistedDisk && !isNew && !fromProfile;
   useEffect(() => {
     const currentHddData = JSON.stringify(hdd);
     const parentHddData = JSON.stringify(data);
 
-    if (currentHddData !== parentHddData) {
+    if (!controllerError && !deviceError && currentHddData !== parentHddData) {
       updateHardDiskData(id, hdd);
     }
-  }, [hdd, id, data, updateHardDiskData]);
+  }, [hdd, id, data, updateHardDiskData, controllerError, deviceError]);
   const handleChange = e => {
     const { name, value } = e.target;
     const updatedKey = Object.keys(hdd).find(key => hdd[key].name === name);
@@ -39,12 +54,16 @@ const HardDisk = ({
         setHdd({
           ...hdd,
           controller: { ...hdd.controller, value },
-          device: { ...hdd.device, value: updatedDeviceInfo.device },
+          device: {
+            ...hdd.device,
+            value: normalizeDeviceValue(updatedDeviceInfo.device),
+          },
           id: { ...hdd.id, value: updatedDeviceInfo.id },
         });
-        setError(null);
+        setControllerError(null);
+        setDeviceError(null);
       } else {
-        setError(
+        setControllerError(
           sprintf(
             __(
               'Reached maximum number of devices for controller %(value)s. Please select another controller.'
@@ -58,12 +77,36 @@ const HardDisk = ({
           device: { ...hdd.device, value: '' },
           id: { ...hdd.id, value: '' },
         });
+        setDeviceError(null);
       }
     } else {
+      const updatedValue =
+        updatedKey === 'device' ? normalizeDeviceValue(value) : value;
+
+      if (updatedKey === 'device') {
+        const validationError = validateDevice(
+          hdd?.controller?.value,
+          updatedValue,
+          id
+        );
+        setDeviceError(validationError);
+      }
+
       const updatedData = {
         ...hdd,
-        [updatedKey]: { ...hdd[updatedKey], value },
+        [updatedKey]: { ...hdd[updatedKey], value: updatedValue },
       };
+
+      if (
+        updatedKey === 'device' &&
+        !validateDevice(hdd?.controller?.value, updatedValue, id)
+      ) {
+        updatedData.id = {
+          ...hdd.id,
+          value: `${hdd?.controller?.value}${updatedValue}`,
+        };
+      }
+
       setHdd(updatedData);
     }
   };
@@ -103,7 +146,7 @@ const HardDisk = ({
         value={hdd?.controller?.value}
         options={ProxmoxComputeSelectors.proxmoxControllersHDDMap}
         onChange={handleChange}
-        error={error}
+        error={controllerError}
         disabled={lockController}
         tooltip={
           lockController
@@ -116,8 +159,7 @@ const HardDisk = ({
         name={hdd?.device?.name}
         value={hdd?.device?.value}
         onChange={handleChange}
-        readOnly
-        tooltip={__('Device value is set automatically.')}
+        error={deviceError}
       />
       <InputField
         name={hdd?.cache?.name}
@@ -155,6 +197,7 @@ HardDisk.propTypes = {
   hidden: PropTypes.bool,
   updateHardDiskData: PropTypes.func,
   createUniqueDevice: PropTypes.func,
+  validateDevice: PropTypes.func,
   nodeId: PropTypes.string,
   fromProfile: PropTypes.bool,
   isNew: PropTypes.bool,
@@ -168,6 +211,7 @@ HardDisk.defaultProps = {
   hidden: 'false',
   updateHardDiskData: Function.prototype,
   createUniqueDevice: Function.prototype,
+  validateDevice: Function.prototype,
   fromProfile: false,
   isNew: false,
   isPersistedDisk: false,

--- a/webpack/components/ProxmoxVmType.js
+++ b/webpack/components/ProxmoxVmType.js
@@ -41,7 +41,10 @@ const ProxmoxVmType = ({
   const handleTabClick = (event, tabIndex) => setActiveTabKey(tabIndex);
 
   const [general, setGeneral] = useState(vmAttrs);
-
+  const [provisionMethodState, setProvisionMethodState] = useState(
+    document.querySelector('input[name="host[provision_method]"]:checked')
+      ?.value || 'build'
+  );
   const paramScope = fromProfile
     ? 'compute_attribute[vm_attrs]'
     : 'host[compute_attributes]';
@@ -53,6 +56,43 @@ const ProxmoxVmType = ({
   const [metaStorages, setMetaStorages] = useState([]);
   const [metaBridges, setMetaBridges] = useState([]);
   const [metaImages, setMetaImages] = useState(images || []);
+  const [selectedImageId, setSelectedImageId] = useState(
+    provisionMethodState === 'image'
+      ? (document.querySelector('#image_selection select')
+          ? document.querySelector('#image_selection select')?.value
+          : document.querySelector('[name$="[image_id]"]')?.value) ?? null
+      : null
+  );
+  const selectedImage =
+    provisionMethodState === 'image'
+      ? metaImages.find(image => image.uuid === selectedImageId)
+      : null;
+
+  useEffect(() => {
+    if (provisionMethodState !== 'image') {
+      if (selectedImageId !== null) {
+        setSelectedImageId(null);
+      }
+      return;
+    }
+
+    if (selectedImageId !== null) return;
+
+    const imageSelect = document.querySelector('#image_selection select');
+    const domValue =
+      (imageSelect ? imageSelect.value : null) ??
+      document.querySelector('[name$="[image_id]"]')?.value ??
+      null;
+
+    if (domValue !== null) {
+      setSelectedImageId(domValue || null);
+      return;
+    }
+
+    if (metaImages.length === 1 && provisionMethodState === 'image') {
+      setSelectedImageId(metaImages[0].uuid);
+    }
+  }, [metaImages, selectedImageId, provisionMethodState]);
 
   useEffect(() => {
     if (registerComp) return undefined;
@@ -134,6 +174,37 @@ const ProxmoxVmType = ({
     setFilteredBridges(filtered);
   }, [nodeIdValue, metaBridges, registerComp]);
 
+  useEffect(() => {
+    const handler = event => {
+      if (event.target?.name !== 'host[provision_method]') return;
+      setProvisionMethodState(event.target.value);
+    };
+    document.addEventListener('change', handler);
+    return () => {
+      document.removeEventListener('change', handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handler = event => {
+      if (provisionMethodState !== 'image') return;
+      const { target } = event;
+      if (!target) return;
+      const { value: targetValue } = target;
+      if (
+        target.closest('#image_selection') ||
+        target.name?.endsWith('[image_id]')
+      ) {
+        setSelectedImageId(targetValue || null);
+      }
+    };
+
+    document.addEventListener('change', handler);
+    return () => {
+      document.removeEventListener('change', handler);
+    };
+  }, [provisionMethodState]);
+
   if (registerComp) {
     return null;
   }
@@ -162,6 +233,8 @@ const ProxmoxVmType = ({
           isLoading={!metaLoaded}
           isTabActive={activeTabKey === 4}
           computeResourceId={computeResourceId}
+          selectedImage={selectedImage}
+          provisionMethodState={provisionMethodState}
         />
       ),
     },
@@ -207,6 +280,12 @@ const ProxmoxVmType = ({
     } else {
       value = targetValue;
     }
+
+    if (name?.endsWith('[image_id]') && fromProfile) {
+      setSelectedImageId(value || null);
+      setProvisionMethodState('image');
+    }
+
     const updatedKey = Object.keys(general).find(
       key => general[key].name === name
     );


### PR DESCRIPTION
- Fixed an issue where image-based provisioning could create a disk with the same controller and device ID as a disk already present in the VM template.
- Added backend support to expose template disk information (disks) with the image object.
- Implemented logic to prevent selecting disk controller/device combinations that already exist in the template.
- Enabled the device field in the UI so users can manually select the device number instead of it being automatically generated.
- Added validation for the device field to prevent users from entering values outside the allowed controller ranges.