### PR TITLE
Fix hard disk deletion not detected during host edit and compute profile

### DIFF
--- a/app/helpers/proxmox_vm_volumes_helper.rb
+++ b/app/helpers/proxmox_vm_volumes_helper.rb
@@ -93,6 +93,7 @@ module ProxmoxVMVolumesHelper
   end
 
   def parse_typed_volume(args, type)
+    return if Foreman::Cast.to_bool(args['_delete'])
     logger.debug("parse_typed_volume(#{type}): args=#{args}")
     disk = parse_hard_disk_volume(args) if volume_type?(args,
       'hard_disk') || volume_type?(args, 'mp') || volume_type?(args, 'rootfs')
@@ -116,6 +117,9 @@ module ProxmoxVMVolumesHelper
 
   def remove_volume_keys(args)
     if args.key?('volumes_attributes')
+      args['volumes_attributes'].delete_if do |_index, volume_attributes|
+        Foreman::Cast.to_bool(volume_attributes['_delete'])
+      end
       args['volumes_attributes'].each_value do |volume_attributes|
         ForemanFogProxmox::HashCollection.remove_keys(volume_attributes, ['_delete'])
       end

--- a/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
@@ -47,13 +47,17 @@ module ForemanFogProxmox
       vm_attrs
     end
 
+    def volume_compute_attributes(volume_attributes)
+      volume_attributes.merge(_delete: '0')
+    end
+
     def vm_compute_attributes(vm)
       vm_attrs = {}
       vm_attrs = vm_attrs.merge(vmid: vm.identity, node_id: vm.node_id, type: vm.type)
       if vm.respond_to?(:config)
         if vm.config.respond_to?(:disks)
           vm_attrs[:volumes_attributes] = Hash[vm.config.disks.each_with_index.map do |disk, idx|
-                                                 [idx.to_s, disk.attributes]
+                                                 [idx.to_s, volume_compute_attributes(disk.attributes)]
                                                end ]
         end
         if vm.config.respond_to?(:interfaces)

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_vm_volumes_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_vm_volumes_helper_test.rb
@@ -35,6 +35,13 @@ module ForemanFogProxmox
             'storage' => 'local-lvm',
             'storage_type' => 'hard_disk',
           },
+          '1' => {
+            '_delete' => '1',
+            'id' => 'scsi1',
+            'volid' => '',
+            'storage' => 'local-lvm',
+            'storage_type' => 'hard_disk',
+          },
         },
       }
 
@@ -42,6 +49,7 @@ module ForemanFogProxmox
         remove_volume_keys(args)
         assert args.key?('volumes_attributes')
         assert args['volumes_attributes'].key?('0')
+        assert_not args['volumes_attributes'].key?('1')
         assert_not args['volumes_attributes']['0'].key?('_delete')
         # assert_not args['volumes_attributes']['0'].key?('storage_type')
       end

--- a/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
@@ -97,7 +97,7 @@ module ForemanFogProxmox
                      }, vm_attrs[:config_attributes]
         assert_not vm_attrs[:config_attributes].key?(:disks)
         assert vm_attrs.key?(:volumes_attributes)
-        assert_equal volume_attributes, vm_attrs[:volumes_attributes]['0']
+        assert_equal volume_attributes.merge(_delete: '0'), vm_attrs[:volumes_attributes]['0']
         assert_not vm_attrs[:config_attributes].key?(:interfaces)
         assert vm_attrs.key?(:interfaces_attributes)
         assert_equal interface_attributes[:id], vm_attrs[:interfaces_attributes]['0'][:id]
@@ -118,7 +118,7 @@ module ForemanFogProxmox
                      }, vm_attrs[:config_attributes]
         assert_not vm_attrs[:config_attributes].key?(:disks)
         assert vm_attrs.key?(:volumes_attributes)
-        assert_equal volume_attributes, vm_attrs[:volumes_attributes]['0']
+        assert_equal volume_attributes.merge(_delete: '0'), vm_attrs[:volumes_attributes]['0']
         assert vm_attrs.key?(:interfaces_attributes)
         assert_equal interface_attributes[:id], vm_attrs[:interfaces_attributes]['0'][:id]
         assert_equal interface_attributes[:compute_attributes][:name],

--- a/webpack/components/ProxmoxServer/components/HardDisk.js
+++ b/webpack/components/ProxmoxServer/components/HardDisk.js
@@ -185,7 +185,11 @@ const HardDisk = ({
         value={hdd?.size?.value}
         onChange={handleChange}
       />
-      <input name={hdd?._delete?.name} type="hidden" value={hidden} />
+      <input
+        name={hdd?._delete?.name}
+        type="hidden"
+        value={hidden ? '1' : '0'}
+      />
     </div>
   );
 };
@@ -208,7 +212,7 @@ HardDisk.defaultProps = {
   data: {},
   storages: [],
   nodeId: '',
-  hidden: 'false',
+  hidden: false,
   updateHardDiskData: Function.prototype,
   createUniqueDevice: Function.prototype,
   validateDevice: Function.prototype,


### PR DESCRIPTION
- Updated UI to send _delete as `'0'`/`'1' `instead of `'true'` and `'false'`, ensuring consistency with other volume attributes (e.g., backup).
- Fixed  issue where deleting a hard disk did not trigger a compute update during host edit and compute profile usage.
- Updated testes to reflect the changes.