### PR TITLE
Fix DHCP behavior and update OS template edit mode

### DIFF
--- a/app/assets/javascripts/foreman_fog_proxmox/proxmox_vm_container.js
+++ b/app/assets/javascripts/foreman_fog_proxmox/proxmox_vm_container.js
@@ -36,8 +36,8 @@ function syncDhcpIP(item, suffix) {
   var $cidr = $fieldset.find('input.proxmox-cidr-' + suffix).first();
   var $gw = $fieldset.find('input.proxmox-gw-' + suffix).first();
 
-  setDisabled($cidr, !checked);
-  setDisabled($gw, !checked);
+  setDisabled($cidr, checked);
+  setDisabled($gw, checked);
 }
 
 function dhcpIPSelected(item, suffix) {

--- a/app/views/compute_resources_vms/form/proxmox/container/_network.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_network.html.erb
@@ -24,11 +24,11 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
     <% dhcp_enabled = ActiveModel::Type::Boolean.new.cast(f.object.dhcp) %>
     <% dhcp6_enabled = ActiveModel::Type::Boolean.new.cast(f.object.dhcp6) %>
     <%= checkbox_f f, :dhcp, :label => _('DHCP IPv4'), :class => 'proxmox-dhcp-ipv4', :onchange => "dhcpIPSelected(this, 'ipv4')" %>
-    <%= text_f f, :cidr, :label => _('CIDR IPv4'), :label_size => "col-md-2", :label_help => _("integer within [0..32]"), :disabled => !dhcp_enabled, :class => 'proxmox-cidr-ipv4' %>
-    <%= text_f f, :gw, :label => _('Gateway IPv4'), :label_size => "col-md-2", :disabled => !dhcp_enabled, :class => 'proxmox-gw-ipv4' %>
+    <%= text_f f, :cidr, :label => _('CIDR IPv4'), :label_size => "col-md-2", :label_help => _("integer within [0..32]"), :disabled => dhcp_enabled, :class => 'proxmox-cidr-ipv4' %>
+    <%= text_f f, :gw, :label => _('Gateway IPv4'), :label_size => "col-md-2", :disabled => dhcp_enabled, :class => 'proxmox-gw-ipv4' %>
     <%= checkbox_f f, :dhcp6, :label => _('DHCP IPv6'), :class => 'proxmox-dhcp-ipv6', :onchange => "dhcpIPSelected(this, 'ipv6')" %>
-    <%= text_f f, :cidr6, :label => _('CIDR IPv6'), :label_size => "col-md-2", :label_help => _("integer within [0..128]"), :disabled => !dhcp6_enabled, :class => 'proxmox-cidr-ipv6' %>
-    <%= text_f f, :gw6, :label => _('Gateway IPv6'), :label_size => "col-md-2", :disabled => !dhcp6_enabled, :class => 'proxmox-gw-ipv6' %>
+    <%= text_f f, :cidr6, :label => _('CIDR IPv6'), :label_size => "col-md-2", :label_help => _("integer within [0..128]"), :disabled => dhcp6_enabled, :class => 'proxmox-cidr-ipv6' %>
+    <%= text_f f, :gw6, :label => _('Gateway IPv6'), :label_size => "col-md-2", :disabled => dhcp6_enabled, :class => 'proxmox-gw-ipv6' %>
     <%= text_f f, :tag, :class => "input-mini", :label => _('VLAN tag'), :label_size => "col-md-2" %>
     <%= text_f f, :rate, :class => "input-mini", :label => _('Rate limit'), :label_size => "col-md-2" %>
     <%= checkbox_f f, :firewall, :label => _('Firewall') %>

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
@@ -12,11 +12,14 @@ const ProxmoxContainerOptions = ({
   storages,
   nodeId,
   computeResourceId,
+  newVm,
+  fromProfile,
 }) => {
   const [opts, setOpts] = useState(options);
   const storagesMap = createStoragesMap(storages, 'vztmpl', nodeId);
 
   const storageValue = opts?.ostemplateStorage?.value || 'local';
+  const isEditMode = !newVm && !fromProfile;
 
   const fromStorages = useMemo(
     () => imagesByStorage(storages, nodeId, storageValue, 'vztmpl'),
@@ -24,7 +27,11 @@ const ProxmoxContainerOptions = ({
   );
 
   const shouldFetchFromAPI =
-    fromStorages.length === 0 && computeResourceId && nodeId && storageValue;
+    !isEditMode &&
+    fromStorages.length === 0 &&
+    computeResourceId &&
+    nodeId &&
+    storageValue;
   const { volumes, loadingVolumes, volumeError } = useVolumes(
     shouldFetchFromAPI ? computeResourceId : null,
     shouldFetchFromAPI ? nodeId : null,
@@ -104,6 +111,7 @@ const ProxmoxContainerOptions = ({
           options={volumesMap}
           value={opts?.ostemplateFile?.value}
           type="select"
+          disabled={isEditMode}
           onChange={handleChange}
           error={
             volumeError ? __('Failed fetching templates please try again.') : ''
@@ -163,6 +171,8 @@ ProxmoxContainerOptions.propTypes = {
   storages: PropTypes.array,
   nodeId: PropTypes.string,
   computeResourceId: PropTypes.number,
+  newVm: PropTypes.bool,
+  fromProfile: PropTypes.bool,
 };
 
 ProxmoxContainerOptions.defaultProps = {
@@ -170,6 +180,8 @@ ProxmoxContainerOptions.defaultProps = {
   storages: [],
   nodeId: '',
   computeResourceId: null,
+  newVm: false,
+  fromProfile: false,
 };
 
 export default ProxmoxContainerOptions;

--- a/webpack/components/ProxmoxContainer/components/NetworkInterface.js
+++ b/webpack/components/ProxmoxContainer/components/NetworkInterface.js
@@ -121,7 +121,7 @@ const NetworkInterface = ({
         type="text"
         value={network?.cidr?.value}
         onChange={handleChange}
-        disabled={!dhcpEnabled}
+        disabled={dhcpEnabled}
       />
       <InputField
         name={network?.gw?.name}
@@ -129,7 +129,7 @@ const NetworkInterface = ({
         type="text"
         value={network?.gw?.value}
         onChange={handleChange}
-        disabled={!dhcpEnabled}
+        disabled={dhcpEnabled}
       />
       <InputField
         name={network?.dhcp6?.name}
@@ -146,7 +146,7 @@ const NetworkInterface = ({
         type="text"
         value={network?.cidr6?.value}
         onChange={handleChange}
-        disabled={!dhcp6Enabled}
+        disabled={dhcp6Enabled}
       />
       <InputField
         name={network?.gw6?.name}
@@ -154,7 +154,7 @@ const NetworkInterface = ({
         type="text"
         value={network?.gw6?.value}
         onChange={handleChange}
-        disabled={!dhcp6Enabled}
+        disabled={dhcp6Enabled}
       />
       <InputField
         name={network?.tag?.name}

--- a/webpack/components/ProxmoxVmType.js
+++ b/webpack/components/ProxmoxVmType.js
@@ -173,6 +173,8 @@ const ProxmoxVmType = ({
           paramScope={paramScope}
           nodeId={general?.nodeId?.value}
           computeResourceId={computeResourceId}
+          newVm={newVm}
+          fromProfile={fromProfile}
         />
       ),
       hardware: <ProxmoxContainerHardware hardware={vmAttrs} />,


### PR DESCRIPTION
- Aligned DHCP IPv4/IPv6 behavior with Proxmox.
- Disabled OS template in edit mode.
- Prevented unnecessary API calls for fetching volumes when in edit mode.