### PR TITLE
Fix Proxmox VM import and association

### DIFF
--- a/app/models/concerns/fog_extensions/proxmox/server.rb
+++ b/app/models/concerns/fog_extensions/proxmox/server.rb
@@ -21,10 +21,16 @@ module FogExtensions
   module Proxmox
     module Server
       extend ActiveSupport::Concern
-      attr_accessor :image_id, :templated, :ostemplate_storage, :ostemplate_file, :password, :start_after_create
+      attr_accessor :image_id, :templated, :ostemplate_storage, :ostemplate_file, :password, :start_after_create, :compute_resource_id
 
       def unique_cluster_identity(compute_resource)
         compute_resource.id.to_s + '_' + identity.to_s
+      end
+
+      def foreman_uuid
+        return identity.to_s if compute_resource_id.nil?
+
+        compute_resource_id.to_s + '_' + identity.to_s
       end
 
       def start

--- a/app/models/concerns/orchestration/proxmox/compute.rb
+++ b/app/models/concerns/orchestration/proxmox/compute.rb
@@ -61,11 +61,8 @@ module Orchestration
         vm.send(fog_attr) || find_address(foreman_attr)
       end
 
-      def computeValue(foreman_attr, fog_attr)
-        value = ''
-        value += compute_resource.id.to_s + '_' if foreman_attr == :uuid
-        value += vm.send(fog_attr).to_s
-        value
+      def computeValue(_foreman_attr, fog_attr)
+        vm.send(fog_attr).to_s
       end
 
       def setVmDetails

--- a/app/models/foreman_fog_proxmox/proxmox.rb
+++ b/app/models/foreman_fog_proxmox/proxmox.rb
@@ -45,6 +45,7 @@ module ForemanFogProxmox
 
     def provided_attributes
       super.merge(
+        :uuid => :foreman_uuid,
         :mac => :mac
       )
     end
@@ -62,10 +63,11 @@ module ForemanFogProxmox
     end
 
     def associated_host(vm)
-      associate_by('mac', vm.mac)
+      associate_by('mac', vm&.mac)
     end
 
     def associate_by(name, attributes)
+      return nil if attributes.blank?
       Host.authorized(:view_hosts,
         Host).joins(:primary_interface).where(:nics => { :primary => true }).where("nics.#{name}".downcase => attributes.downcase).readonly(false).first
     end

--- a/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
@@ -19,8 +19,13 @@
 
 module ForemanFogProxmox
   module ProxmoxComputeAttributes
+    FOREMAN_INTERFACE_ATTRIBUTES = [:id, :mac, :ip, :ip6].freeze
+    PROXMOX_MAC_ATTRIBUTES = [:macaddr, :hwaddr].freeze
+    PROXMOX_INTERFACE_METADATA = [:identifier, :compute_attributes].freeze
+
     def host_compute_attrs(host)
-      ostype = host.compute_attributes['config_attributes']['ostype']
+      config = host.compute_attributes['config_attributes'] || {}
+      ostype = config['ostype']
       type = host.compute_attributes['type']
       case type
       when 'lxc'
@@ -41,9 +46,21 @@ module ForemanFogProxmox
     end
 
     def interface_compute_attributes(interface_attributes)
-      vm_attrs = ForemanFogProxmox::HashCollection.new_hash_reject_keys(interface_attributes, [:identifier, :macaddr, :hwaddr])
-      vm_attrs[:dhcp] = (interface_attributes[:ip] == 'dhcp') ? '1' : '0'
-      vm_attrs[:dhcp6] = (interface_attributes[:ip6] == 'dhcp') ? '1' : '0'
+      attrs = interface_attributes.with_indifferent_access
+      provider_attrs = attrs[:compute_attributes].present? ? attrs[:compute_attributes].with_indifferent_access : ActiveSupport::HashWithIndifferentAccess.new
+
+      vm_attrs = FOREMAN_INTERFACE_ATTRIBUTES.index_with do |key|
+        attrs[key] || provider_attrs.delete(key)
+      end.compact
+      vm_attrs[:mac] ||= attrs[:macaddr] || attrs[:hwaddr] || provider_attrs.delete(:macaddr) || provider_attrs.delete(:hwaddr)
+
+      attrs.except(*FOREMAN_INTERFACE_ATTRIBUTES, *PROXMOX_MAC_ATTRIBUTES, *PROXMOX_INTERFACE_METADATA).each do |key, value|
+        provider_attrs[key] = value
+      end
+
+      provider_attrs[:dhcp] = (vm_attrs[:ip] == 'dhcp') ? '1' : '0'
+      provider_attrs[:dhcp6] = (vm_attrs[:ip6] == 'dhcp') ? '1' : '0'
+      vm_attrs[:compute_attributes] = provider_attrs
       vm_attrs
     end
 

--- a/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
@@ -46,9 +46,10 @@ module ForemanFogProxmox
     def vms(opts = {})
       vms = []
       nodes.each { |node| vms += node.servers.all + node.containers.all }
+      vms.each { |vm| attach_compute_resource_id(vm) }
       if opts.key?(:eager_loading) && opts[:eager_loading]
         vms_eager = []
-        vms.each { |vm| vms_eager << vm.collection.get(vm.identity) }
+        vms.each { |vm| vms_eager << attach_compute_resource_id(vm.collection.get(vm.identity)) }
         vms = vms_eager
       end
       ForemanFogProxmox::Vms.new(vms)
@@ -71,12 +72,21 @@ module ForemanFogProxmox
     def find_vm_in_servers_by_vmid(servers, vmid)
       vm = servers.get(vmid) unless ForemanFogProxmox::Value.empty?(vmid)
       pool_owner(vm) if vm
-      vm
+      attach_compute_resource_id(vm)
     rescue Fog::Errors::NotFound
       nil
     rescue StandardError => e
       Foreman::Logging.exception(format(_('Failed retrieving proxmox server vm by vmid=%<vmid>s'), vmid: vmid), e)
       raise(ActiveRecord::RecordNotFound, e)
+    end
+
+    private
+
+    def attach_compute_resource_id(virtual_machine)
+      return virtual_machine if virtual_machine.nil?
+
+      virtual_machine.compute_resource_id = id if virtual_machine.respond_to?(:compute_resource_id=)
+      virtual_machine
     end
   end
 end

--- a/app/views/compute_resources_vms/index/_proxmox.html.erb
+++ b/app/views/compute_resources_vms/index/_proxmox.html.erb
@@ -42,6 +42,7 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
         <%= action_buttons(
                 vm_power_action(vm, authorizer),
 		vm_associate_link(vm),
+          vm_import_action(vm),
                 display_delete_if_authorized(hash_for_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.unique_cluster_identity(@compute_resource)).merge(:auth_object => @compute_resource, :authorizer => authorizer))) %>
         </td>
       </tr>

--- a/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
@@ -87,6 +87,23 @@ module ForemanFogProxmox
       end
       excluded_keys = [:vmid, :disks, :interfaces]
 
+      it 'maps flat interface attributes into foreman nic structure' do
+        vm_attrs = @cr.interface_compute_attributes(
+          id: 'net0',
+          macaddr: '36:25:8C:53:0C:50',
+          model: 'virtio',
+          bridge: 'vmbr0'
+        )
+
+        assert_equal 'net0', vm_attrs[:id]
+        assert_equal '36:25:8C:53:0C:50', vm_attrs[:mac]
+        assert_equal 'virtio', vm_attrs[:compute_attributes][:model]
+        assert_equal 'vmbr0', vm_attrs[:compute_attributes][:bridge]
+        assert_equal '0', vm_attrs[:compute_attributes][:dhcp]
+        assert_equal '0', vm_attrs[:compute_attributes][:dhcp6]
+        assert_not vm_attrs[:compute_attributes].key?(:macaddr)
+      end
+
       it 'converts a server to hash' do
         vm, config_attributes, volume_attributes, interface_attributes = mock_server_vm
         vm_attrs = @cr.vm_compute_attributes(vm)
@@ -101,11 +118,13 @@ module ForemanFogProxmox
         assert_not vm_attrs[:config_attributes].key?(:interfaces)
         assert vm_attrs.key?(:interfaces_attributes)
         assert_equal interface_attributes[:id], vm_attrs[:interfaces_attributes]['0'][:id]
-        assert_equal interface_attributes[:mac], vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:macaddr]
+        assert_equal interface_attributes[:mac], vm_attrs[:interfaces_attributes]['0'][:mac]
         assert_equal interface_attributes[:compute_attributes][:model],
           vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:model]
         assert_equal interface_attributes[:compute_attributes][:bridge],
           vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:bridge]
+        assert_equal '0', vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:dhcp]
+        assert_equal '0', vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:dhcp6]
       end
 
       it 'converts a container to hash' do
@@ -121,11 +140,13 @@ module ForemanFogProxmox
         assert_equal volume_attributes.merge(_delete: '0'), vm_attrs[:volumes_attributes]['0']
         assert vm_attrs.key?(:interfaces_attributes)
         assert_equal interface_attributes[:id], vm_attrs[:interfaces_attributes]['0'][:id]
+        assert_equal interface_attributes[:mac], vm_attrs[:interfaces_attributes]['0'][:mac]
         assert_equal interface_attributes[:compute_attributes][:name],
           vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:name]
-        assert_equal interface_attributes[:mac], vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:hwaddr]
         assert_equal interface_attributes[:compute_attributes][:bridge],
           vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:bridge]
+        assert_equal '0', vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:dhcp]
+        assert_equal '0', vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:dhcp6]
       end
     end
   end

--- a/test/unit/foreman_fog_proxmox/proxmox_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_test.rb
@@ -48,6 +48,23 @@ module ForemanFogProxmox
       assert_equal host, (as_admin { cr.associated_host(vm) })
     end
 
+    test '#provided_attributes maps uuid to foreman_uuid' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+
+      assert_equal :foreman_uuid, cr.provided_attributes[:uuid]
+    end
+
+    test '#setComputeDetails uses proxmox uuid without adding another prefix' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+      host = FactoryBot.build_stubbed(:host, :compute_resource => cr)
+      host.vm = mock('vm')
+      cr.stubs(:provided_attributes).returns({ :uuid => :foreman_uuid })
+      host.vm.expects(:foreman_uuid).returns("#{cr.id}_199")
+
+      assert host.send(:setComputeDetails), "Failed to setComputeDetails, errors: #{host.errors.full_messages}"
+      assert_equal "#{cr.id}_199", host.uuid
+    end
+
     test '#node' do
       node = mock('node')
       cr = FactoryBot.build_stubbed(:proxmox_cr)


### PR DESCRIPTION
- Overwrote uuid mapping in provided_attributes.
- Removed legacy UUID prefixing logic to avoid double-prefix.
- Normalized NIC attributes by keeping id, mac, ip, ip6 at top level.
- Added  Import as managed Host and Import as unmanaged Host options to the actions dropdown.
- Added some unit tests for UUID mapping and NIC attribute transformation.