### PR TITLE
Fix nil identity crash and filter disabled/inactive storages

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
@@ -31,12 +31,12 @@ module ForemanFogProxmox
     end
 
     def cloudinit_defaults
-      { storage_type: 'cloud_init', id: 'ide0', storage: storages.first.identity.to_s, media: 'cdrom' }
+      { storage_type: 'cloud_init', id: 'ide0', storage: storages.first&.identity.to_s, media: 'cdrom' }
     end
 
     def hard_disk_typed_defaults(vm_type)
       options = {}
-      volume_attributes_h = { storage: storages.first.identity.to_s, size: '8' }
+      volume_attributes_h = { storage: storages.first&.identity.to_s, size: '8' }
       case vm_type
       when 'qemu'
         controller = 'virtio'
@@ -69,18 +69,18 @@ module ForemanFogProxmox
     end
 
     def interface_defaults(id = 'net0')
-      { id: id, compute_attributes: { model: 'virtio', name: 'eth0', bridge: bridges.first.identity.to_s } }
+      { id: id, compute_attributes: { model: 'virtio', name: 'eth0', bridge: bridges.first&.identity.to_s } }
     end
 
     def interface_typed_defaults(type)
       interface_attributes_h = { id: 'net0', compute_attributes: {} }
       if type == 'qemu'
         interface_attributes_h[:compute_attributes] =
-          { model: 'virtio', bridge: bridges.first.identity.to_s }
+          { model: 'virtio', bridge: bridges.first&.identity.to_s }
       end
       if type == 'lxc'
         interface_attributes_h[:compute_attributes] =
-          { name: 'eth0', bridge: bridges.first.identity.to_s, dhcp: 1, dhcp6: 1 }
+          { name: 'eth0', bridge: bridges.first&.identity.to_s, dhcp: 1, dhcp6: 1 }
       end
       interface_attributes_h
     end

--- a/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
@@ -32,7 +32,7 @@ module ForemanFogProxmox
       node ||= default_node
       storages = node.storages.list_by_content_type type
       logger.debug("storages(): node_id #{node_id} type #{type}")
-      storages.sort_by(&:storage)
+      storages.reject { |s| s.enabled.to_i.zero? || s.active.to_i.zero? }.sort_by(&:storage)
     end
 
     def bridges(node_id = default_node_id)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_new_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_new_test.rb
@@ -32,6 +32,50 @@ module ForemanFogProxmox
     include ProxmoxContainerMockFactory
     include ProxmoxVMHelper
 
+    describe 'defaults with empty storages or bridges' do
+      before do
+        @cr = FactoryBot.build_stubbed(:proxmox_cr)
+        @cr.stubs(:storages).returns([])
+        @cr.stubs(:bridges).returns([])
+      end
+
+      it 'does not crash for cloudinit_defaults when storages are empty' do
+        defaults = @cr.cloudinit_defaults
+
+        assert_equal '', defaults[:storage]
+      end
+
+      it 'does not crash for qemu hard_disk_typed_defaults when storages are empty' do
+        defaults = @cr.hard_disk_typed_defaults('qemu')
+
+        assert_equal '', defaults[:storage]
+      end
+
+      it 'does not crash for lxc hard_disk_typed_defaults when storages are empty' do
+        defaults = @cr.hard_disk_typed_defaults('lxc')
+
+        assert_equal '', defaults[:storage]
+      end
+
+      it 'does not crash for interface_defaults when bridges are empty' do
+        defaults = @cr.interface_defaults
+
+        assert_equal '', defaults[:compute_attributes][:bridge]
+      end
+
+      it 'does not crash for qemu interface_typed_defaults when bridges are empty' do
+        defaults = @cr.interface_typed_defaults('qemu')
+
+        assert_equal '', defaults[:compute_attributes][:bridge]
+      end
+
+      it 'does not crash for lxc interface_typed_defaults when bridges are empty' do
+        defaults = @cr.interface_typed_defaults('lxc')
+
+        assert_equal '', defaults[:compute_attributes][:bridge]
+      end
+    end
+
     describe 'new_vm' do
       before do
         @cr = FactoryBot.build_stubbed(:proxmox_cr)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_queries_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_queries_test.rb
@@ -23,6 +23,7 @@ require 'factories/foreman_fog_proxmox/proxmox_node_mock_factory'
 require 'factories/foreman_fog_proxmox/proxmox_server_mock_factory'
 require 'factories/foreman_fog_proxmox/proxmox_container_mock_factory'
 require 'active_support/core_ext/hash/indifferent_access'
+require 'ostruct'
 
 module ForemanFogProxmox
   class ProxmoxVMQueriesTest < ActiveSupport::TestCase
@@ -31,6 +32,72 @@ module ForemanFogProxmox
     include ProxmoxServerMockFactory
     include ProxmoxContainerMockFactory
     include ProxmoxVMHelper
+
+    describe 'storages' do
+      before do
+        @cr = ForemanFogProxmox::Proxmox.new
+        @storages_collection = mock('storages_collection')
+        @node = mock('node')
+        @node.stubs(:storages).returns(@storages_collection)
+        nodes = mock('nodes')
+        nodes.stubs(:get).with('proxmox').returns(@node)
+        client = mock('client')
+        client.stubs(:nodes).returns(nodes)
+        @cr.stubs(:client).returns(client)
+      end
+
+      it 'returns only active and enabled storages' do
+        active_storage = OpenStruct.new(storage: 'local', enabled: 1, active: 1)
+        @storages_collection.stubs(:list_by_content_type).with('images').returns([active_storage])
+
+        assert_equal [active_storage], @cr.storages('proxmox')
+      end
+
+      it 'returns active storages sorted by storage name' do
+        storage_zfs = OpenStruct.new(storage: 'local-zfs', enabled: 1, active: 1)
+        storage_lvm = OpenStruct.new(storage: 'local-lvm', enabled: 1, active: 1)
+        @storages_collection.stubs(:list_by_content_type).with('images').returns([storage_zfs, storage_lvm])
+
+        assert_equal %w[local-lvm local-zfs], @cr.storages('proxmox').map(&:storage)
+      end
+
+      it 'filters invalid storages and keeps valid ones' do
+        valid = OpenStruct.new(storage: 'good', enabled: 1, active: 1)
+        invalid = OpenStruct.new(storage: 'bad', enabled: 0, active: 1)
+
+        @storages_collection.stubs(:list_by_content_type).with('images').returns([valid, invalid])
+
+        assert_equal [valid], @cr.storages('proxmox')
+      end
+
+      it 'excludes disabled storages (enabled=0)' do
+        disabled_storage = OpenStruct.new(storage: 'disabled-store', enabled: 0, active: 1)
+        @storages_collection.stubs(:list_by_content_type).with('images').returns([disabled_storage])
+
+        assert_empty @cr.storages('proxmox')
+      end
+
+      it 'excludes inactive storages (active=0)' do
+        inactive_storage = OpenStruct.new(storage: 'inactive-store', enabled: 1, active: 0)
+        @storages_collection.stubs(:list_by_content_type).with('images').returns([inactive_storage])
+
+        assert_empty @cr.storages('proxmox')
+      end
+
+      it 'treats nil enabled as inactive and excludes it' do
+        nil_enabled_storage = OpenStruct.new(storage: 'nil-enabled', enabled: nil, active: 1)
+        @storages_collection.stubs(:list_by_content_type).with('images').returns([nil_enabled_storage])
+
+        assert_empty @cr.storages('proxmox')
+      end
+
+      it 'treats nil active as inactive and excludes it' do
+        nil_active_storage = OpenStruct.new(storage: 'nil-active', enabled: 1, active: nil)
+        @storages_collection.stubs(:list_by_content_type).with('images').returns([nil_active_storage])
+
+        assert_empty @cr.storages('proxmox')
+      end
+    end
 
     describe 'find_vm_by_uuid' do
       it 'returns nil when the uuid does not match' do


### PR DESCRIPTION
- Fixed NoMethodError: undefined method 'identity' for nil:NilClass crash in proxmox_vm_new.rb by using safe navigation operator (&.) on storages.first and bridges.first.

- Filtered out inactive and disabled storages.

- Added  unit tests covering nil crash fix and storage filtering behavior.