### PR TITLE
Fix CD-ROM preservation on edit compute profile/host

### DIFF
--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -76,7 +76,7 @@ module ProxmoxVMAttrsHelper
         keys = ['id', 'volid', 'storage_type', 'storage', 'controller', 'device', 'cache', 'size', '_delete', 'backup']
         type = 'hard_disk'
       elsif  vol.cdrom?
-        keys = ['id', 'storage_type', 'cdrom', 'storage', 'volid']
+        keys = ['id', 'storage_type', 'cdrom', 'storage', 'volid', '_delete']
         type = 'cdrom'
       elsif vol.cloud_init?
         keys = ['id', 'volid', 'storage_type', 'storage', 'controller', 'device']

--- a/app/helpers/proxmox_vm_cdrom_helper.rb
+++ b/app/helpers/proxmox_vm_cdrom_helper.rb
@@ -26,8 +26,15 @@ require 'foreman_fog_proxmox/hash_collection'
 module ProxmoxVMCdromHelper
   def parse_server_cdrom(args)
     cdrom_media = args['cdrom'] if args.key?('cdrom')
-    cdrom_image = args['volid'] if args.key?('volid')
-    volid = cdrom_image.empty? ? cdrom_media : cdrom_image
+    return {} unless cdrom_media
+    cdrom_image = args['volid'] if args.key?('volid') && cdrom_media == 'image'
+    volid = if cdrom_image.present?
+              cdrom_image
+            elsif cdrom_media == 'none'
+              'none'
+            elsif ['physical', 'cdrom'].include?(cdrom_media)
+              'cdrom'
+            end
     return {} unless volid
 
     { id: 'ide2', volid: volid, media: 'cdrom' }

--- a/app/helpers/proxmox_vm_volumes_helper.rb
+++ b/app/helpers/proxmox_vm_volumes_helper.rb
@@ -86,15 +86,29 @@ module ProxmoxVMVolumesHelper
     if args.key?('storage_type')
       args['storage_type'] == type
     else
+      return true if type == 'cdrom' && args.key?('cdrom')
+
       Fog::Proxmox::DiskHelper.cloud_init?(args['volid']) if type == 'cloud_init'
       Fog::Proxmox::DiskHelper.cdrom?(args['volid']) if type == 'cdrom'
       Fog::Proxmox::DiskHelper.disk?(args['id']) if ['hard_disk', 'rootfs', 'mp'].include?(type)
     end
   end
 
+  def validate_cdrom_image_permission!(volume_attributes)
+    volume_attributes = volume_attributes.with_indifferent_access
+
+    return unless volume_type?(volume_attributes, 'cdrom')
+    return unless volume_attributes[:cdrom].to_s == 'image'
+    return if User.current&.can?(:attach_cdrom_image, self)
+
+    raise ::Foreman::Exception,
+      _('You are not authorized to attach or change CD-ROM ISO images.')
+  end
+
   def parse_typed_volume(args, type)
     return if Foreman::Cast.to_bool(args['_delete'])
     logger.debug("parse_typed_volume(#{type}): args=#{args}")
+    validate_cdrom_image_permission!(args)
     disk = parse_hard_disk_volume(args) if volume_type?(args,
       'hard_disk') || volume_type?(args, 'mp') || volume_type?(args, 'rootfs')
     disk = parse_server_cloudinit(args) if volume_type?(args, 'cloud_init')

--- a/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
@@ -64,8 +64,15 @@ module ForemanFogProxmox
       vm_attrs
     end
 
+    def cdrom_compute_attributes(attrs)
+      return unless attrs[:storage_type].to_s == 'cdrom' || attrs[:media].to_s == 'cdrom'
+
+      { cdrom: attrs[:volid].to_s }
+    end
+
     def volume_compute_attributes(volume_attributes)
-      volume_attributes.merge(_delete: '0')
+      attrs = volume_attributes.merge(_delete: '0')
+      cdrom_compute_attributes(attrs) || attrs
     end
 
     def vm_compute_attributes(vm)

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -113,7 +113,10 @@ module ForemanFogProxmox
 
         volumes_attributes = new_attributes['volumes_attributes']
         logger.debug("save_vm(#{uuid}) volumes_attributes=#{volumes_attributes}")
-        volumes_attributes&.each_value { |volume_attributes| save_volume(vm, volume_attributes) }
+        volumes_attributes&.each_value do |volume_attributes|
+          validate_cdrom_image_permission!(volume_attributes)
+          save_volume(vm, volume_attributes)
+        end
 
         efidisk_attributes = new_attributes['efidisk_attributes']
         if vm.config.efidisk.present? && efidisk_attributes.empty?

--- a/app/models/foreman_fog_proxmox/proxmox_volumes.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_volumes.rb
@@ -47,7 +47,7 @@ module ForemanFogProxmox
     def update_volume_required?(old_volume_attributes, new_volume_attributes)
       old_h = ForemanFogProxmox::HashCollection.new_hash_reject_empty_values(old_volume_attributes)
       new_h = ForemanFogProxmox::HashCollection.new_hash_reject_empty_values(new_volume_attributes)
-      new_h = ForemanFogProxmox::HashCollection.new_hash_reject_keys(new_h, ['cdrom', 'cloudinit', 'storage_type'])
+      new_h = ForemanFogProxmox::HashCollection.new_hash_reject_keys(new_h, ['cloudinit', 'storage_type'])
       !ForemanFogProxmox::HashCollection.equals?(old_h.with_indifferent_access, new_h.with_indifferent_access)
     end
 
@@ -112,6 +112,8 @@ module ForemanFogProxmox
     end
 
     def volume_exists?(vm, volume_attributes)
+      return vm.config.disks.get('ide2').present? if volume_type?(volume_attributes, 'cdrom')
+
       disk = vm.config.disks.get(volume_attributes['id'])
       return false unless disk
 
@@ -128,14 +130,14 @@ module ForemanFogProxmox
     end
 
     def extract_id(vm, volume_attributes)
-      id = ''
+      return 'ide2' if volume_type?(volume_attributes, 'cdrom')
+
       if volume_exists?(vm, volume_attributes)
-        id = volume_attributes['id']
+        volume_attributes['id']
       else
         device = vm.container? ? 'mp' : volume_attributes['controller']
-        id = volume_type?(volume_attributes, 'cdrom') ? 'ide2' : device + volume_attributes['device']
+        device + volume_attributes['device']
       end
-      id
     end
 
     def add_volume(vm, id, volume_attributes)
@@ -145,7 +147,10 @@ module ForemanFogProxmox
         disk_attributes[:storage] = volume_attributes['storage']
         disk_attributes[:size] = volume_attributes['size']
       elsif volume_type?(volume_attributes, 'cdrom')
-        disk_attributes[:volid] = volume_attributes[:iso]
+        cdrom_attributes = parse_server_cdrom(volume_attributes)
+        return if cdrom_attributes.empty?
+
+        disk_attributes.merge!(cdrom_attributes)
       elsif volume_type?(volume_attributes, 'cloud_init')
         disk_attributes[:storage] = volume_attributes['storage']
         disk_attributes[:volid] = "#{volume_attributes['storage']}:cloudinit"
@@ -164,7 +169,11 @@ module ForemanFogProxmox
         else
           disk = vm.config.disks.get(id)
           normalized_volume_attributes = normalize_existing_volume_attributes(disk, volume_attributes)
-          update_volume(vm, disk, normalized_volume_attributes) if update_volume_required?(disk.attributes, normalized_volume_attributes)
+          if volume_type?(volume_attributes, 'cdrom')
+            update_volume(vm, disk, normalized_volume_attributes)
+          elsif update_volume_required?(disk.attributes, normalized_volume_attributes)
+            update_volume(vm, disk, normalized_volume_attributes)
+          end
         end
       else
         add_volume(vm, id, volume_attributes)

--- a/app/views/compute_resources_vms/form/proxmox/_base.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_base.html.erb
@@ -44,6 +44,7 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   props = {
     vmAttrs: vm_attrs,
     computeResourceId: compute_resource.id,
+    canAttachCdromImage: User.current.can?(:attach_cdrom_image, compute_resource),
     propsLoaded: false,
     fromProfile: from_profile,
     newVm: new_vm,

--- a/lib/foreman_fog_proxmox/engine.rb
+++ b/lib/foreman_fog_proxmox/engine.rb
@@ -54,6 +54,8 @@ module ForemanFogProxmox
                :bridges_by_id_and_node,
                :volumes_by_node_and_storage,
                :metadata] }
+            permission :attach_cdrom_image, {},
+              :resource_type => 'ComputeResource'
           end
         end
       end

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_server_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_server_helper_test.rb
@@ -107,6 +107,16 @@ module ForemanFogProxmox
         assert_equal 'cdrom', cdrom[:media]
       end
 
+      test '#cdrom physical' do
+        cdrom = parse_server_cdrom('cdrom' => 'physical')
+        assert cdrom.key?(:id)
+        assert_equal 'ide2', cdrom[:id]
+        assert cdrom.key?(:volid)
+        assert_equal 'cdrom', cdrom[:volid]
+        assert cdrom.key?(:media)
+        assert_equal 'cdrom', cdrom[:media]
+      end
+
       test '#vm' do
         expected_vm = ActiveSupport::HashWithIndifferentAccess.new(
           {

--- a/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
@@ -150,6 +150,13 @@ module ForemanFogProxmox
         assert_not vm_attrs[:compute_attributes].key?(:macaddr)
       end
 
+      it 'normalizes cdrom volume attributes to form shape' do
+        assert_equal({ cdrom: 'none' }, @cr.volume_compute_attributes({ storage_type: 'cdrom', volid: 'none', media: 'cdrom' }))
+        assert_equal({ cdrom: 'cdrom' }, @cr.volume_compute_attributes({ storage_type: 'cdrom', volid: 'cdrom', media: 'cdrom' }))
+        assert_equal({ cdrom: 'local-lvm:iso/debian-netinst.iso' },
+          @cr.volume_compute_attributes({ storage_type: 'cdrom', volid: 'local-lvm:iso/debian-netinst.iso', media: 'cdrom' }))
+      end
+
       it 'converts a server to hash' do
         vm, config_attributes, volume_attributes, interface_attributes = mock_server_vm
         vm_attrs = @cr.vm_compute_attributes(vm)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_update_cdrom_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_update_cdrom_test.rb
@@ -35,7 +35,8 @@ module ForemanFogProxmox
         @cr = FactoryBot.build_stubbed(:proxmox_cr)
       end
 
-      it 'saves modified server config with added cdrom' do
+      it 'saves modified server config with added cdrom image when user has permission' do
+        User.current = users(:admin)
         uuid = '100'
         config = mock('config')
         disks = mock('disks')
@@ -58,6 +59,7 @@ module ForemanFogProxmox
         vm.stubs(:type).returns('qemu')
         vm.stubs(:node_id).returns('proxmox')
         @cr.stubs(:find_vm_by_uuid).returns(vm)
+        User.current.stubs(:can?).with(:attach_cdrom_image, @cr).returns(true)
         new_attributes = {
           'templated' => '0',
           'node_id' => 'proxmox',
@@ -86,6 +88,54 @@ module ForemanFogProxmox
         vm.expects(:attach, expected_volume_attr)
         vm.expects(:update, expected_config_attr)
         @cr.save_vm(uuid, new_attributes)
+      end
+
+      it 'rejects added cdrom image when user has no permission' do
+        User.current = users(:admin)
+        uuid = '100'
+        config = mock('config')
+        disks = mock('disks')
+        disks.stubs(:get).returns
+        config.stubs(:disks).returns(disks)
+        config.stubs(:efidisk).returns(nil)
+        config.stubs(:attributes).returns(:cores => '')
+        vm = mock('vm')
+        vm.stubs(:identity).returns(uuid)
+        vm.stubs(:attributes).returns('' => '')
+        vm.stubs(:config).returns(config)
+        vm.stubs(:container?).returns(false)
+        vm.stubs(:type).returns('qemu')
+        vm.stubs(:node_id).returns('proxmox')
+        @cr.stubs(:find_vm_by_uuid).returns(vm)
+        User.current.stubs(:can?).with(:attach_cdrom_image, @cr).returns(false)
+        new_attributes = {
+          'templated' => '0',
+          'node_id' => 'proxmox',
+          'config_attributes' => {
+            'cores' => '1',
+            'cpulimit' => '1',
+          },
+          'volumes_attributes' => {
+            '0' => {
+              'id' => 'ide2',
+              '_delete' => '',
+              'device' => '2',
+              'controller' => 'ide',
+              'storage_type' => 'cdrom',
+              'storage' => 'local-lvm',
+              'cdrom' => 'image',
+              'volid' => 'local-lvm:iso/ubuntu-20_4.iso',
+            },
+          },
+        }.with_indifferent_access
+        @cr.stubs(:parse_server_vm).returns('vmid' => '100', 'node_id' => 'proxmox', 'type' => 'qemu', 'cores' => '1',
+          'cpulimit' => '1', 'onboot' => '0')
+        vm.expects(:attach).never
+        vm.expects(:update).never
+
+        assert_raises(::Foreman::Exception) do
+          @cr.save_vm(uuid, new_attributes)
+        end
       end
 
       it 'saves modified server config with removed cdrom' do

--- a/webpack/components/ProxmoxServer/ProxmoxServerStorage.js
+++ b/webpack/components/ProxmoxServer/ProxmoxServerStorage.js
@@ -33,6 +33,7 @@ const ProxmoxServerStorage = ({
   isTabActive,
   selectedImage,
   provisionMethodState,
+  canAttachCdromImage,
 }) => {
   const bootDiskId = React.useMemo(() => {
     if (!bootOrder) return null;
@@ -70,6 +71,8 @@ const ProxmoxServerStorage = ({
   const [nextId, setNextId] = useState(0);
   const [cdRom, setCdRom] = useState(false);
   const [cdRomData, setCdRomData] = useState(null);
+  const [cdRomHidden, setCdRomHidden] = useState(false);
+  const [cdRomIsNew, setCdRomIsNew] = useState(false);
   const [efiDisk, setEfiDisk] = useState(false);
   const [efiDiskData, setEfiDiskData] = useState(null);
   const [nextDeviceNumbers, setNextDeviceNumbers] = useState({
@@ -309,7 +312,7 @@ const ProxmoxServerStorage = ({
           value: '',
         },
         storageType: {
-          name: `${paramScope}[volumes_attributes][${nextId}][storageType]`,
+          name: `${paramScope}[volumes_attributes][${nextId}][storage_type]`,
           value: 'cdrom',
         },
         storage: {
@@ -318,17 +321,29 @@ const ProxmoxServerStorage = ({
         },
         cdrom: {
           name: `${paramScope}[volumes_attributes][${nextId}][cdrom]`,
-          value: '',
+          value: 'none',
+        },
+        _delete: {
+          name: `${paramScope}[volumes_attributes][${nextId}][_delete]`,
         },
       };
 
       setCdRom(true);
       setCdRomData(initCDRom);
+      setCdRomHidden(false);
+      setCdRomIsNew(!isPreExisting);
     },
     [cdRom, nextId, paramScope, createUniqueDevice]
   );
 
-  const removeCDRom = () => setCdRom(false);
+  const removeCDRom = () => {
+    if (cdRomIsNew) {
+      setCdRom(false);
+      setCdRomData(null);
+    } else {
+      setCdRomHidden(true);
+    }
+  };
 
   const addEfiDisk = useCallback(
     (event, initialData = null, isPreExisting = false) => {
@@ -432,14 +447,18 @@ const ProxmoxServerStorage = ({
           </FormHelperText>
         )}
         {cdRom && cdRomData && (
-          <CDRom
-            onRemove={removeCDRom}
-            data={cdRomData}
-            storages={storages}
-            nodeId={nodeId}
-            computeResourceId={computeResourceId}
-            isTabActive={isTabActive}
-          />
+          <div style={{ display: cdRomHidden ? 'none' : 'block' }}>
+            <CDRom
+              onRemove={removeCDRom}
+              data={cdRomData}
+              storages={storages}
+              nodeId={nodeId}
+              computeResourceId={computeResourceId}
+              isTabActive={isTabActive}
+              canAttachCdromImage={canAttachCdromImage}
+              hidden={cdRomHidden}
+            />
+          </div>
         )}
         {efiDisk && efiDiskData && (
           <EFIDisk
@@ -537,6 +556,7 @@ ProxmoxServerStorage.propTypes = {
   isTabActive: PropTypes.bool,
   selectedImage: PropTypes.object,
   provisionMethodState: PropTypes.string,
+  canAttachCdromImage: PropTypes.bool,
 };
 
 ProxmoxServerStorage.defaultProps = {
@@ -553,6 +573,7 @@ ProxmoxServerStorage.defaultProps = {
   isTabActive: false,
   selectedImage: null,
   provisionMethodState: '',
+  canAttachCdromImage: false,
 };
 
 export default ProxmoxServerStorage;

--- a/webpack/components/ProxmoxServer/components/CDRom.js
+++ b/webpack/components/ProxmoxServer/components/CDRom.js
@@ -6,6 +6,9 @@ import {
   PageSection,
   Radio,
   Spinner,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -13,7 +16,15 @@ import { createStoragesMap } from '../../ProxmoxStoragesUtils';
 import InputField from '../../common/FormInputs';
 import useVolumes from '../../hooks/useVolumes';
 
-const CDRom = ({ onRemove, data, storages, nodeId, computeResourceId }) => {
+const CDRom = ({
+  onRemove,
+  data,
+  storages,
+  nodeId,
+  computeResourceId,
+  canAttachCdromImage,
+  hidden,
+}) => {
   const [cdrom, setCdrom] = useState(data);
 
   const storagesMap = useMemo(
@@ -85,13 +96,20 @@ const CDRom = ({ onRemove, data, storages, nodeId, computeResourceId }) => {
   const imagesMap = useMemo(
     () => [
       { value: '', label: '' },
-      ...volumes.map(v => ({ value: v.volid, label: v.volid })),
+      ...volumes
+        .filter(v => v.content === 'iso')
+        .map(v => ({ value: v.volid, label: v.volid })),
     ],
     [volumes]
   );
 
   return (
     <div style={{ position: 'relative' }}>
+      <input
+        name={cdrom?._delete?.name}
+        type="hidden"
+        value={hidden ? '1' : '0'}
+      />
       <div
         style={{
           display: 'flex',
@@ -130,7 +148,7 @@ const CDRom = ({ onRemove, data, storages, nodeId, computeResourceId }) => {
           name={cdrom?.cdrom?.name}
           label={__('None')}
           value="none"
-          isChecked={cdrom?.cdrom?.value === 'none'}
+          isChecked={mediaValue === 'none'}
           onChange={(e, _) => handleMediaChange(_, e)}
         />
         <Radio
@@ -138,8 +156,8 @@ const CDRom = ({ onRemove, data, storages, nodeId, computeResourceId }) => {
           id="radio-physical"
           name={cdrom?.cdrom?.name}
           label={__('Physical')}
-          value="physical"
-          isChecked={cdrom?.cdrom?.value === 'physical'}
+          value="cdrom"
+          isChecked={mediaValue === 'cdrom'}
           onChange={(e, _) => handleMediaChange(_, e)}
         />
         <Radio
@@ -148,12 +166,25 @@ const CDRom = ({ onRemove, data, storages, nodeId, computeResourceId }) => {
           name={cdrom?.cdrom?.name}
           label={__('Image')}
           value="image"
-          isChecked={cdrom?.cdrom?.value === 'image'}
+          isChecked={mediaValue === 'image'}
           onChange={(e, _) => handleMediaChange(_, e)}
+          isDisabled={!canAttachCdromImage}
         />
       </div>
 
-      {cdrom?.cdrom?.value === 'image' && (
+      {!canAttachCdromImage && (
+        <FormHelperText>
+          <HelperText id="helper-cdrom-image-permission">
+            <HelperTextItem variant="warning">
+              {__(
+                'You are not authorized to attach or change CD-ROM ISO images'
+              )}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
+
+      {mediaValue === 'image' && (
         <PageSection padding={{ default: 'noPadding' }}>
           <Title ouiaId="proxmox-server-cdrom-image-title" headingLevel="h5">
             {__('Image')}
@@ -170,6 +201,7 @@ const CDRom = ({ onRemove, data, storages, nodeId, computeResourceId }) => {
             }
             options={storagesMap}
             onChange={handleChange}
+            disabled={!canAttachCdromImage}
           />
 
           {loadingVolumes ? (
@@ -191,6 +223,7 @@ const CDRom = ({ onRemove, data, storages, nodeId, computeResourceId }) => {
               value={cdrom?.volid?.value}
               options={imagesMap}
               onChange={handleChange}
+              disabled={!canAttachCdromImage}
               error={
                 volumeError
                   ? __('Failed fetching images ISO please try again.')
@@ -198,8 +231,6 @@ const CDRom = ({ onRemove, data, storages, nodeId, computeResourceId }) => {
               }
             />
           )}
-
-          <input name={cdrom?.storageType?.name} type="hidden" value="cdrom" />
         </PageSection>
       )}
     </div>
@@ -224,10 +255,19 @@ CDRom.propTypes = {
     storageType: PropTypes.shape({
       name: PropTypes.string.isRequired,
     }).isRequired,
+    _delete: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+    }),
   }).isRequired,
   storages: PropTypes.array.isRequired,
   nodeId: PropTypes.string.isRequired,
   computeResourceId: PropTypes.number.isRequired,
+  canAttachCdromImage: PropTypes.bool.isRequired,
+  hidden: PropTypes.bool,
+};
+
+CDRom.defaultProps = {
+  hidden: false,
 };
 
 export default CDRom;

--- a/webpack/components/ProxmoxVmType.js
+++ b/webpack/components/ProxmoxVmType.js
@@ -35,6 +35,7 @@ const ProxmoxVmType = ({
   registerComp,
   untemplatable,
   computeResourceId,
+  canAttachCdromImage,
   propsLoaded,
 }) => {
   const [activeTabKey, setActiveTabKey] = useState(0);
@@ -233,6 +234,7 @@ const ProxmoxVmType = ({
           isLoading={!metaLoaded}
           isTabActive={activeTabKey === 4}
           computeResourceId={computeResourceId}
+          canAttachCdromImage={canAttachCdromImage}
           selectedImage={selectedImage}
           provisionMethodState={provisionMethodState}
         />
@@ -415,6 +417,7 @@ ProxmoxVmType.propTypes = {
   registerComp: PropTypes.bool,
   untemplatable: PropTypes.bool,
   computeResourceId: PropTypes.number,
+  canAttachCdromImage: PropTypes.bool,
   propsLoaded: PropTypes.bool,
 };
 
@@ -426,6 +429,7 @@ ProxmoxVmType.defaultProps = {
   registerComp: false,
   untemplatable: false,
   computeResourceId: null,
+  canAttachCdromImage: false,
   propsLoaded: false,
 };
 


### PR DESCRIPTION
- Prevented CD-ROM from disappearing when editing compute profile or host.
- Fixed the frontend field name from storageType to storage_type.
- Fixed the issue of CD-ROM media type  never triggered a Proxmox VM update by normalizing the CD-ROM attributes to match form shape so the diff can detect changes.
- Added new permission  to only allow user with admin role to attach an image to the CD-ROM.
- Disabled image radio button and  displayed a warning message in the UI when the user doesn't have the required permission to attach an image to the CD-ROM.
- Fixed CD-ROM deletion functionality. 