### PR TITLE
Fix adding default disk volume for image-based provisioning

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
@@ -129,10 +129,11 @@ module ForemanFogProxmox
       super.merge(vmid: next_vmid, node_id: default_node_id, type: 'qemu')
     end
 
-    def vm_typed_instance_defaults(type)
+    def vm_typed_instance_defaults(type, new_attr = {})
       defaults = vm_instance_defaults
       defaults = defaults.merge(config_attributes: config_attributes(type))
-      defaults = add_default_typed_volume(defaults)
+      # Image-based provisioning uses storage from the selected image, so no default volumes are needed.
+      defaults = add_default_typed_volume(defaults) unless new_attr['provision_method'] == 'image'
       add_default_typed_interface(type, defaults)
     end
 
@@ -191,11 +192,11 @@ module ForemanFogProxmox
       new_attr_type ||= type
       logger.debug("new_typed_vm(#{type}): new_attr_type=#{new_attr_type}")
       logger.debug("new_typed_vm(#{type}): new_attr=#{new_attr}'")
-      options = (!new_attr.key?('vmid') || ForemanFogProxmox::Value.empty?(new_attr['vmid'])) ? vm_typed_instance_defaults(type).merge(new_attr).merge(type: type) : new_attr
+      options = (!new_attr.key?('vmid') || ForemanFogProxmox::Value.empty?(new_attr['vmid'])) ? vm_typed_instance_defaults(type, new_attr).merge(new_attr).merge(type: type) : new_attr
       logger.debug("new_typed_vm(#{type}): options=#{options}")
       vm_h = parse_typed_vm(options, type).deep_symbolize_keys
       logger.debug("new_typed_vm(#{type}): vm_h=#{vm_h}")
-      vm_h = vm_h.merge(vm_typed_instance_defaults(type)) if vm_h.empty?
+      vm_h = vm_h.merge(vm_typed_instance_defaults(type, new_attr)) if vm_h.empty?
       logger.debug(format(_('new_typed_vm(%<type>s) with vm_typed_instance_defaults: vm_h=%<vm_h>s'), type: type, vm_h: vm_h))
       node.send(vm_collection(type)).new(vm_h)
     end

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_new_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_new_test.rb
@@ -111,5 +111,31 @@ module ForemanFogProxmox
         assert_equal vm, @cr.new_vm(attr)
       end
     end
+
+    describe 'vm_typed_instance_defaults' do
+      before do
+        @cr = FactoryBot.build_stubbed(:proxmox_cr)
+        @cr.stubs(:vm_instance_defaults).returns(vmid: '101', node_id: 'proxmox', type: 'qemu')
+        @cr.stubs(:config_attributes).with('qemu').returns(memory: '1024')
+        @cr.stubs(:hard_disk_typed_defaults).with('qemu').returns(id: 'virtio0')
+        @cr.stubs(:hard_disk_typed_defaults).with('lxc').returns(id: 'rootfs')
+        @cr.stubs(:interface_typed_defaults).with('qemu').returns(id: 'net0')
+      end
+
+      it 'adds default volumes for non-image provisioning' do
+        defaults = @cr.vm_typed_instance_defaults('qemu')
+
+        assert defaults.key?(:volumes_attributes)
+        assert_equal({ id: 'virtio0' }, defaults[:volumes_attributes][0])
+        assert_equal({ id: 'rootfs' }, defaults[:volumes_attributes][1])
+      end
+
+      it 'does not add default volumes for image provisioning' do
+        defaults = @cr.vm_typed_instance_defaults('qemu', 'provision_method' => 'image')
+
+        assert_not defaults.key?(:volumes_attributes)
+        assert defaults.key?(:interfaces_attributes)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Prevented adding default disk volume when provision_method is image.
- Passed  new_attr to vm_typed_instance_defaults to make provisioning context available.
