### PR TITLE
Fix mount point storage dropdown

### DIFF
--- a/webpack/components/ProxmoxContainer/ProxmoxContainerStorage.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerStorage.js
@@ -117,13 +117,12 @@ const ProxmoxContainerStorage = ({
         const newMountPoint = {
           id: newNextId,
           data: initMP,
-          storagesMap,
         };
         setMountPoints(prev => [...prev, newMountPoint]);
         return newNextId;
       });
     },
-    [nextId, paramScope, storagesMap]
+    [nextId, paramScope]
   );
 
   const removeMountPoint = idToRemove => {
@@ -221,7 +220,7 @@ const ProxmoxContainerStorage = ({
               key={mountPoint.id}
               id={mountPoint.id}
               data={mountPoint.data}
-              storagesMap={mountPoint.storagesMap}
+              storagesMap={storagesMap}
             />
           </div>
         ))}


### PR DESCRIPTION
- During edit mode, mount points were initialized before storages finished loading
As a result, storagesMap was saved as an empty array inside mount point so I removed stale storagesMap from mount point state and passed current storagesMap directly to MountPoint during render