### PR TITLE
ostype 'other' works for FreeBSD hosts in Proxmox

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
@@ -32,12 +32,10 @@ module ForemanFogProxmox
         host.compute_attributes['config_attributes'].store('hostname', host.name)
       when 'qemu'
         host.compute_attributes['config_attributes'].store('name', host.name)
-        unless  host.operatingsystem.type == 'Freebsd' && ostype == 'other'
-          unless compute_os_types(host).include?(ostype)
-            raise ::Foreman::Exception,
-              format(_('Operating system family %<type>s is not consistent with %<ostype>s'), type: host.operatingsystem.type,
-                ostype: ostype)
-          end
+        unless compute_os_types(host).include?(ostype) || (host.operatingsystem.type == 'Freebsd' && ostype == 'other')
+          raise ::Foreman::Exception,
+            format(_('Operating system family %<type>s is not consistent with %<ostype>s'), type: host.operatingsystem.type,
+              ostype: ostype)
         end
       end
       super

--- a/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
@@ -32,10 +32,12 @@ module ForemanFogProxmox
         host.compute_attributes['config_attributes'].store('hostname', host.name)
       when 'qemu'
         host.compute_attributes['config_attributes'].store('name', host.name)
-        unless compute_os_types(host).include?(ostype)
-          raise ::Foreman::Exception,
-            format(_('Operating system family %<type>s is not consistent with %<ostype>s'), type: host.operatingsystem.type,
-              ostype: ostype)
+        unless  host.operatingsystem.type == 'Freebsd' && ostype == 'other'
+          unless compute_os_types(host).include?(ostype)
+            raise ::Foreman::Exception,
+              format(_('Operating system family %<type>s is not consistent with %<ostype>s'), type: host.operatingsystem.type,
+                ostype: ostype)
+          end
         end
       end
       super


### PR DESCRIPTION
ostype 'other' works for FreeBSD hosts in Proxmox