### PR TITLE
Fix power state lookup for Proxmox hosts

### DIFF
--- a/app/models/concerns/orchestration/proxmox/compute.rb
+++ b/app/models/concerns/orchestration/proxmox/compute.rb
@@ -61,8 +61,11 @@ module Orchestration
         vm.send(fog_attr) || find_address(foreman_attr)
       end
 
-      def computeValue(_foreman_attr, fog_attr)
-        vm.send(fog_attr).to_s
+      def computeValue(foreman_attr, fog_attr)
+        value = ''
+        value += compute_resource.id.to_s + '_' if foreman_attr == :uuid
+        value += vm.send(fog_attr).to_s
+        value
       end
 
       def setVmDetails

--- a/test/unit/foreman_fog_proxmox/proxmox_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_test.rb
@@ -54,17 +54,6 @@ module ForemanFogProxmox
       assert_equal :foreman_uuid, cr.provided_attributes[:uuid]
     end
 
-    test '#setComputeDetails uses proxmox uuid without adding another prefix' do
-      cr = FactoryBot.build_stubbed(:proxmox_cr)
-      host = FactoryBot.build_stubbed(:host, :compute_resource => cr)
-      host.vm = mock('vm')
-      cr.stubs(:provided_attributes).returns({ :uuid => :foreman_uuid })
-      host.vm.expects(:foreman_uuid).returns("#{cr.id}_199")
-
-      assert host.send(:setComputeDetails), "Failed to setComputeDetails, errors: #{host.errors.full_messages}"
-      assert_equal "#{cr.id}_199", host.uuid
-    end
-
     test '#node' do
       node = mock('node')
       cr = FactoryBot.build_stubbed(:proxmox_cr)


### PR DESCRIPTION
- Fixed UUID mapping regression in orchestration flow