### PR TITLE
Fix Proxmox NIC compute profile inheritance

### DIFF
--- a/app/helpers/proxmox_form_helper.rb
+++ b/app/helpers/proxmox_form_helper.rb
@@ -130,8 +130,11 @@ module ProxmoxFormHelper
   def proxmox_valid_interface_compute_attributes?(compute_attributes, vm_type)
     return false unless compute_attributes.respond_to?(:keys)
 
-    valid_keys = interface_compute_attributes_typed_keys(vm_type)
-    compute_attributes.keys.map(&:to_s).all? { |key| valid_keys.include?(key) }
+    compute_attribute_keys = compute_attributes.keys.map(&:to_s)
+    required_keys = interface_compute_attributes_required_typed_keys(vm_type)
+    missing_keys = required_keys - compute_attribute_keys
+
+    required_keys.any? && missing_keys.empty?
   end
 
   def extract_attr(attrs, key)

--- a/app/helpers/proxmox_vm_interfaces_helper.rb
+++ b/app/helpers/proxmox_vm_interfaces_helper.rb
@@ -55,6 +55,17 @@ module ProxmoxVMInterfacesHelper
     keys
   end
 
+  def interface_compute_attributes_required_typed_keys(type)
+    case type
+    when 'qemu'
+      ['model']
+    when 'lxc'
+      ['name']
+    else
+      []
+    end
+  end
+
   def interface_common_typed_keys(type)
     ['id', (type == 'qemu') ? 'macaddr' : 'hwaddr']
   end

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_form_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_form_helper_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# This file is part of ForemanFogProxmox.
+
+# ForemanFogProxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# ForemanFogProxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'test_plugin_helper'
+
+module ForemanFogProxmox
+  class ProxmoxFormHelperTest < ActiveSupport::TestCase
+    include ProxmoxFormHelper
+
+    describe 'interface compute attribute validation' do
+      let(:required_attrs) do
+        {
+          'qemu' => { 'model' => 'virtio' },
+          'lxc' => { 'name' => 'eth0' },
+        }
+      end
+
+      it 'rejects attributes when required keys are missing' do
+        required_attrs.each_key do |vm_type|
+          assert_not send(:proxmox_valid_interface_compute_attributes?, { 'bridge' => 'vmbr0' }, vm_type)
+        end
+      end
+
+      it 'accepts attributes when required keys are present' do
+        required_attrs.each do |vm_type, attrs|
+          assert send(:proxmox_valid_interface_compute_attributes?, attrs, vm_type)
+        end
+      end
+
+      it 'accepts attributes when required keys are present with other keys' do
+        required_attrs.each do |vm_type, attrs|
+          assert send(:proxmox_valid_interface_compute_attributes?, attrs.merge('bridge' => 'vmbr0'), vm_type)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Fixed NIC compute profile attributes not being preserved during host creation
- Kept fallback to default NIC attributes for invalid/stale provider data
- Replaced strict key validation with required-key validation
- Added tests for NIC compute attribute validation