### PR TITLE
Fix update detection for compute attributes

### DIFF
--- a/app/models/foreman_fog_proxmox/compute_attributes_update_detector.rb
+++ b/app/models/foreman_fog_proxmox/compute_attributes_update_detector.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright 2026
+
+# This file is part of ForemanFogProxmox.
+
+# ForemanFogProxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# ForemanFogProxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>.
+
+module ForemanFogProxmox
+  module ComputeAttributesUpdateDetector
+    def update_required?(old_attrs, new_attrs)
+      old_attrs = old_attrs.deep_symbolize_keys
+      new_attrs = new_attrs.deep_symbolize_keys
+      new_attrs.each do |key, new_v|
+        old_v = old_attrs[key]
+        if new_v.is_a?(Hash)
+          unless old_v.is_a?(Hash)
+            logger.debug "Scheduling compute instance update because #{key} changed it's value from '#{old_v}' (#{old_v.class}) to '#{new_v}' (#{new_v.class})"
+            return true
+          end
+          return true if update_required?(old_v, new_v)
+        elsif old_v.to_s != new_v.to_s
+          logger.debug "Scheduling compute instance update because #{key} changed it's value from '#{old_v}' (#{old_v.class}) to '#{new_v}' (#{new_v.class})"
+          return true
+        end
+      end
+      false
+    end
+  end
+end

--- a/app/models/foreman_fog_proxmox/proxmox.rb
+++ b/app/models/foreman_fog_proxmox/proxmox.rb
@@ -35,6 +35,7 @@ module ForemanFogProxmox
     include ProxmoxOperatingSystems
     include ProxmoxVersion
     include ProxmoxConsole
+    include ComputeAttributesUpdateDetector
     validates :url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :presence => true
     validates :auth_method, :presence => true, :inclusion => { in: ['access_ticket', 'user_token'],
       message: ->(value) do format('%<value>s is not a valid authentication method', { value: value }) end }

--- a/test/unit/foreman_fog_proxmox/proxmox_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_test.rb
@@ -54,11 +54,86 @@ module ForemanFogProxmox
       assert_equal :foreman_uuid, cr.provided_attributes[:uuid]
     end
 
+    test '#update_required? detects added HDD attributes' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+      old_attrs = hdd_compute_attrs(hdd_attrs('0'))
+      new_attrs = hdd_compute_attrs(hdd_attrs('0').merge('1' => hdd_attributes('virtio1', 'virtio', '1')))
+
+      assert cr.update_required?(old_attrs, new_attrs)
+    end
+
+    test '#update_required? detects removed HDD attributes' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+
+      old_attrs = hdd_compute_attrs(
+        hdd_attrs('0').merge('1' => hdd_attributes('virtio1', 'virtio', '1'))
+      )
+
+      new_attrs = hdd_compute_attrs(
+        hdd_attrs('0').merge('1' => { '_delete' => '1' })
+      )
+
+      assert cr.update_required?(old_attrs, new_attrs)
+    end
+
+    test '#update_required? detects modified existing HDD attributes' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+      old_attrs = hdd_compute_attrs(hdd_attrs('0'))
+      new_attrs = hdd_compute_attrs(hdd_attrs('0').deep_merge('0' => { 'size' => '20' }))
+
+      assert cr.update_required?(old_attrs, new_attrs)
+    end
+
+    test '#update_required? detects modified CPU flag' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+      old_attrs = { 'config_attributes' => { 'spectre' => '0' } }
+      new_attrs = { 'config_attributes' => { 'spectre' => '+1' } }
+
+      assert cr.update_required?(old_attrs, new_attrs)
+    end
+
+    test '#update_required? detects modified network interface' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+      old_attrs = { 'interfaces_attributes' => { '0' => { 'id' => 'net0', 'bridge' => 'vmbr0' } } }
+      new_attrs = { 'interfaces_attributes' => { '0' => { 'id' => 'net0', 'bridge' => 'vmbr1' } } }
+
+      assert cr.update_required?(old_attrs, new_attrs)
+    end
+
+    test '#update_required? detects added network interface' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+      old_attrs = { 'interfaces_attributes' => { '0' => { 'id' => 'net0' } } }
+      new_attrs = { 'interfaces_attributes' => { '0' => { 'id' => 'net0' }, '1' => { 'id' => 'net1' } } }
+
+      assert cr.update_required?(old_attrs, new_attrs)
+    end
+
     test '#node' do
       node = mock('node')
       cr = FactoryBot.build_stubbed(:proxmox_cr)
       cr.stubs(:node).returns(node)
       assert_equal node, (as_admin { cr.node })
+    end
+
+    private
+
+    def hdd_compute_attrs(volumes_attrs)
+      { 'volumes_attributes' => volumes_attrs }
+    end
+
+    def hdd_attrs(index)
+      { index => hdd_attributes('scsi0', 'scsi', '0') }
+    end
+
+    def hdd_attributes(id, controller, device)
+      {
+        'id' => id,
+        'storage_type' => 'hard_disk',
+        'controller' => controller,
+        'device' => device,
+        'storage' => 'local-lvm',
+        'size' => '10',
+      }
     end
   end
 end


### PR DESCRIPTION
- Overrode update_required? in  Proxmox and preserved the original Foreman recursive comparison behavior
- Fixed missing compute updates when adding new hard disks in edit mode
- Added tests for adding/removing/modifying HDDs