### PR TITLE
Fix cloudinit ISO attachment to prioritize 'local' storage

### DIFF
--- a/app/helpers/proxmox_vm_cloudinit_helper.rb
+++ b/app/helpers/proxmox_vm_cloudinit_helper.rb
@@ -111,7 +111,8 @@ module ProxmoxVMCloudinitHelper
   end
 
   def attach_cloudinit_iso(node, iso)
-    storage = storages(node, 'iso')[0]
+    iso_storages = storages(node, 'iso')
+    storage = iso_storages.detect { |entry| entry.storage == 'local' } || iso_storages[0]
     volume = storage.volumes.detect { |v| v.volid.include? File.basename(iso) }
     { ide2: "#{volume.volid},media=cdrom" }
   end


### PR DESCRIPTION
On my proxmox installation, I have a storage called "BACKUP_TMP" which does not have ISO but does have some backups. For whatever reason, this is the first to be returned in the array by the call to `storage = storages(node, 'iso')`.

Therefore, `volume = storage.volumes.detect { |v| v.volid.include? File.basename(iso) }` becomes `Nil`.

This PR fixes this behavior to prefer the storage called `local`.