### PR TITLE
Fix double UUID prefixing for image base deployment

### DIFF
--- a/app/models/concerns/orchestration/proxmox/compute.rb
+++ b/app/models/concerns/orchestration/proxmox/compute.rb
@@ -63,7 +63,14 @@ module Orchestration
 
       def computeValue(foreman_attr, fog_attr)
         value = ''
-        value += compute_resource.id.to_s + '_' if foreman_attr == :uuid
+
+        if foreman_attr == :uuid
+          vm_value = vm.send(fog_attr).to_s
+          return vm_value if vm_value.match?(/\A\d+_\d+\z/)
+
+          value += compute_resource.id.to_s + '_'
+        end
+
         value += vm.send(fog_attr).to_s
         value
       end

--- a/test/unit/foreman_fog_proxmox/proxmox_orchestration_compute_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_orchestration_compute_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module ForemanFogProxmox
+  class ProxmoxOrchestrationComputeTest < ActiveSupport::TestCase
+    class ComputeValueHost
+      include Orchestration::Proxmox::Compute
+
+      attr_accessor :compute_resource, :vm
+    end
+
+    test '#computeValue prefixes raw vmid for uuid' do
+      host = host_with_vm_value('113')
+
+      assert_equal '4_113', host.computeValue(:uuid, :foreman_uuid)
+    end
+
+    test '#computeValue does not prefix existing proxmox uuid' do
+      host = host_with_vm_value('4_113')
+
+      assert_equal '4_113', host.computeValue(:uuid, :foreman_uuid)
+    end
+
+    private
+
+    def host_with_vm_value(value)
+      host = ComputeValueHost.new
+      host.compute_resource = OpenStruct.new(id: 4)
+      host.vm = OpenStruct.new(foreman_uuid: value)
+      host
+    end
+  end
+end


### PR DESCRIPTION
- Fixed double prefixing during image based deployment that caused VM lookups to fail because `extract_vmid` resolved the wrong VMID.
- A unit test was added to verify both provisioning paths:
    -  Image-based deployment (where the UUID may already be prefixed)
    -  Network provisioning (where the UUID still needs to be prefixed)