### PR TITLE
Add full clone option for compute resources/profiles

### DIFF
--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -131,6 +131,7 @@ module ProxmoxVMAttrsHelper
       ostemplate_storage: vms.ostemplate_storage,
       ostemplate_file: vms.ostemplate_file,
       start_after_create: vms.start_after_create,
+      full_clone: vms.full_clone,
       templated: vms.templated,
     }
     vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname]

--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -131,6 +131,7 @@ module ProxmoxVMAttrsHelper
       ostemplate_storage: vms.ostemplate_storage,
       ostemplate_file: vms.ostemplate_file,
       start_after_create: vms.start_after_create,
+      full_clone: vms.full_clone,
       templated: vms.templated,
       is_secure_boot: vms.config.secure_boot?,
     }

--- a/app/helpers/proxmox_vm_config_helper.rb
+++ b/app/helpers/proxmox_vm_config_helper.rb
@@ -41,7 +41,7 @@ module ProxmoxVMConfigHelper
 
   def general_a(type)
     general_a = ['node_id', 'type', 'config_attributes', 'efidisk_attributes', 'volumes_attributes', 'interfaces_attributes', 'image_id']
-    general_a += ['firmware_type', 'provision_method', 'container_volumes', 'server_volumes', 'start_after_create']
+    general_a += ['firmware_type', 'provision_method', 'container_volumes', 'server_volumes', 'start_after_create', 'full_clone']
     general_a += ['name'] if type == 'lxc'
     general_a
   end

--- a/app/models/concerns/fog_extensions/proxmox/server.rb
+++ b/app/models/concerns/fog_extensions/proxmox/server.rb
@@ -21,7 +21,7 @@ module FogExtensions
   module Proxmox
     module Server
       extend ActiveSupport::Concern
-      attr_accessor :image_id, :templated, :ostemplate_storage, :ostemplate_file, :password, :start_after_create, :compute_resource_id
+      attr_accessor :image_id, :templated, :ostemplate_storage, :ostemplate_file, :password, :start_after_create, :full_clone, :compute_resource_id
 
       def unique_cluster_identity(compute_resource)
         compute_resource.id.to_s + '_' + identity.to_s

--- a/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
@@ -24,6 +24,7 @@ module ForemanFogProxmox
     PROXMOX_INTERFACE_METADATA = [:identifier, :compute_attributes].freeze
 
     def host_compute_attrs(host)
+      @provisioning_full_clone = host.compute_attributes['full_clone'] || host.compute_attributes[:full_clone]
       config = host.compute_attributes['config_attributes'] || {}
       ostype = config['ostype']
       type = host.compute_attributes['type']
@@ -76,24 +77,36 @@ module ForemanFogProxmox
     end
 
     def vm_compute_attributes(vm)
-      vm_attrs = {}
-      vm_attrs = vm_attrs.merge(vmid: vm.identity, node_id: vm.node_id, type: vm.type)
-      if vm.respond_to?(:config)
-        if vm.config.respond_to?(:disks)
-          vm_attrs[:volumes_attributes] = Hash[vm.config.disks.each_with_index.map do |disk, idx|
-                                                 [idx.to_s, volume_compute_attributes(disk.attributes)]
-                                               end ]
-        end
-        if vm.config.respond_to?(:interfaces)
-          vm_attrs[:interfaces_attributes] = Hash[vm.config.interfaces.each_with_index.map do |interface, idx|
-                                                    [idx.to_s, interface_compute_attributes(interface.attributes)]
-                                                  end ]
-        end
-        vm_attrs[:config_attributes] = vm.config.attributes.reject do |key, value|
-          not_config_key?(vm, key) || ForemanFogProxmox::Value.empty?(value.to_s) || Fog::Proxmox::DiskHelper.disk?(key.to_s) || Fog::Proxmox::NicHelper.nic?(key.to_s)
-        end
+      vm_attrs = { vmid: vm.identity, node_id: vm.node_id, type: vm.type }
+      full_clone = vm.try(:full_clone) || @provisioning_full_clone
+      vm_attrs[:full_clone] = full_clone unless full_clone.nil?
+      return vm_attrs unless vm.respond_to?(:config)
+
+      vm_attrs.merge(vm_config_compute_attributes(vm))
+    end
+
+    private
+
+    def vm_config_compute_attributes(vm)
+      attrs = { config_attributes: vm_raw_config_attributes(vm) }
+      attrs[:volumes_attributes] = vm_volumes_compute_attributes(vm) if vm.config.respond_to?(:disks)
+      attrs[:interfaces_attributes] = vm_interfaces_compute_attributes(vm) if vm.config.respond_to?(:interfaces)
+      attrs
+    end
+
+    def vm_volumes_compute_attributes(vm)
+      Hash[vm.config.disks.each_with_index.map { |disk, idx| [idx.to_s, volume_compute_attributes(disk.attributes)] }]
+    end
+
+    def vm_interfaces_compute_attributes(vm)
+      Hash[vm.config.interfaces.each_with_index.map { |iface, idx| [idx.to_s, interface_compute_attributes(iface.attributes)] }]
+    end
+
+    def vm_raw_config_attributes(vm)
+      vm.config.attributes.reject do |key, value|
+        not_config_key?(vm, key) || ForemanFogProxmox::Value.empty?(value.to_s) ||
+          Fog::Proxmox::DiskHelper.disk?(key.to_s) || Fog::Proxmox::NicHelper.nic?(key.to_s)
       end
-      vm_attrs
     end
   end
 end

--- a/app/models/foreman_fog_proxmox/proxmox_images.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_images.rb
@@ -83,10 +83,11 @@ module ForemanFogProxmox
       find_vm_by_uuid(uuid)
     end
 
-    def clone_from_image(image_id, vmid)
-      logger.debug("create_vm(): clone #{image_id} in #{vmid}")
+    def clone_from_image(image_id, vmid, full_clone: false)
+      logger.debug("create_vm(): clone #{image_id} in #{vmid} full_clone=#{full_clone}")
       image = find_vm_by_uuid(image_id)
-      image.clone(vmid)
+      clone_options = full_clone ? { full: 1 } : {}
+      image.clone(vmid, clone_options)
       find_vm_by_uuid(id.to_s + '_' + vmid.to_s)
     end
   end

--- a/app/models/foreman_fog_proxmox/proxmox_images.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_images.rb
@@ -70,9 +70,10 @@ module ForemanFogProxmox
       find_vm_by_uuid(uuid)
     end
 
-    def clone_from_image(image, vmid)
-      logger.debug("create_vm(): clone #{image.identity} in #{vmid}")
-      image.clone(vmid)
+    def clone_from_image(image, vmid, full_clone: false)
+      logger.debug("create_vm(): clone #{image.identity} in #{vmid} full_clone=#{full_clone}")
+      clone_options = full_clone ? { full: 1 } : {}
+      image.clone(vmid, clone_options)
       find_vm_by_uuid(id.to_s + '_' + vmid.to_s)
     end
   end

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -39,7 +39,9 @@ module ForemanFogProxmox
       image_id = args[:image_id]
       remove_volume_keys(args)
       if image_id
-        vm = clone_from_image(image_id, vmid)
+        is_full_clone = full_clone?(args)
+        vm = clone_from_image(image_id, vmid, full_clone: is_full_clone)
+        vm.full_clone = is_full_clone ? '1' : '0'
         vm.update(compute_clone_attributes(args, vm.container?, type))
         update_pool(vm, args[:pool]) if args[:pool]
       else
@@ -51,6 +53,10 @@ module ForemanFogProxmox
       logger.warn("failed to create vm: #{e}")
       destroy_vm id.to_s + '_' + vm.vmid.to_s if vm
       raise e
+    end
+
+    def full_clone?(args)
+      Foreman::Cast.to_bool(args[:full_clone])
     end
 
     def assign_vmid(vmid, node, log: true)
@@ -71,7 +77,8 @@ module ForemanFogProxmox
         options = { :hostname => args[:name] }
         parsed_args.merge(options)
       end
-      parsed_args.reject { |k| k == 'pool' }
+      excluded_keys = ['pool', 'full_clone']
+      parsed_args.reject { |k| excluded_keys.include?(k) }
     end
 
     def destroy_vm(uuid)
@@ -94,7 +101,7 @@ module ForemanFogProxmox
 
     def compute_config_attributes(parsed_attr)
       excluded_keys = [:vmid, :templated, :ostemplate, :ostemplate_file, :ostemplate_storage, :volumes_attributes,
-                       :pool]
+                       :pool, :full_clone]
       config_attributes = parsed_attr.reject { |key, _value| excluded_keys.include? key.to_sym }
       ForemanFogProxmox::HashCollection.remove_empty_values(config_attributes)
       config_attributes = config_attributes.reject { |key, _value| Fog::Proxmox::DiskHelper.disk?(key) }

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -39,11 +39,7 @@ module ForemanFogProxmox
       image_id = args[:image_id]
       remove_volume_keys(args)
       if image_id
-        image = find_vm_by_uuid(image_id)
-        validate_image_template_disk_slots!(image, args) if type == 'qemu'
-        vm = clone_from_image(image, vmid)
-        vm.update(compute_clone_attributes(args, vm.container?, type, image: image))
-        update_pool(vm, args[:pool]) if args[:pool]
+        vm = create_vm_from_image(image_id, vmid, args, type)
       else
         logger.warn("create vm: args=#{args}")
         vm = node.send(vm_collection(type)).create(parse_typed_vm(args, type))
@@ -57,6 +53,21 @@ module ForemanFogProxmox
       logger.warn("failed to create vm: #{e}")
       destroy_vm id.to_s + '_' + vm.vmid.to_s if vm
       raise e
+    end
+
+    def create_vm_from_image(image_id, vmid, args, type)
+      image = find_vm_by_uuid(image_id)
+      validate_image_template_disk_slots!(image, args) if type == 'qemu'
+      is_full_clone = full_clone?(args)
+      vm = clone_from_image(image, vmid, full_clone: is_full_clone)
+      vm.full_clone = is_full_clone ? '1' : '0'
+      vm.update(compute_clone_attributes(args, vm.container?, type, image: image))
+      update_pool(vm, args[:pool]) if args[:pool]
+      vm
+    end
+
+    def full_clone?(args)
+      Foreman::Cast.to_bool(args[:full_clone])
     end
 
     def assign_vmid(vmid, node, log: true)
@@ -78,7 +89,8 @@ module ForemanFogProxmox
         options = { :hostname => args[:name] }
         parsed_args.merge(options)
       end
-      parsed_args.reject { |k| k == 'pool' }
+      excluded_keys = ['pool', 'full_clone']
+      parsed_args.reject { |k| excluded_keys.include?(k) }
     end
 
     def destroy_vm(uuid)
@@ -101,7 +113,7 @@ module ForemanFogProxmox
 
     def compute_config_attributes(parsed_attr)
       excluded_keys = [:vmid, :templated, :ostemplate, :ostemplate_file, :ostemplate_storage, :volumes_attributes,
-                       :pool]
+                       :pool, :full_clone]
       config_attributes = parsed_attr.reject { |key, _value| excluded_keys.include? key.to_sym }
       ForemanFogProxmox::HashCollection.remove_empty_values(config_attributes)
       config_attributes = config_attributes.reject { |key, _value| Fog::Proxmox::DiskHelper.disk?(key) }

--- a/app/views/compute_resources_vms/form/proxmox/_base.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_base.html.erb
@@ -38,6 +38,23 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <%= webpacked_plugins_js_for :foreman_fog_proxmox %>
 <% end %>
 
+<% if from_profile && defined?(@set) && @set&.vm_attrs
+     profile_fc = @set.vm_attrs['full_clone'] || @set.vm_attrs[:full_clone]
+     f.object.full_clone = profile_fc unless profile_fc.nil?
+   end %>
+<% unless new_vm
+     stored_fc = host&.compute_attributes && (host.compute_attributes['full_clone'] || host.compute_attributes[:full_clone])
+     if stored_fc.nil? && host&.compute_profile_id && host&.compute_resource
+       begin
+         profile_attrs = host.compute_resource.compute_profile_attributes_for(host.compute_profile_id)
+         stored_fc = profile_attrs && (profile_attrs['full_clone'] || profile_attrs[:full_clone]) if profile_attrs
+       rescue StandardError => e
+         Rails.logger.warn("ForemanFogProxmox: failed to load compute profile attributes: #{e.message}")
+       end
+     end
+     f.object.full_clone = stored_fc unless stored_fc.nil?
+   end %>
+
 <%
   vm_attrs = object_to_attributes_hash(f.object, from_profile, checked)
 

--- a/app/views/compute_resources_vms/form/proxmox/_base.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_base.html.erb
@@ -38,6 +38,11 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <%= webpacked_plugins_js_for :foreman_fog_proxmox %>
 <% end %>
 
+<% if from_profile && defined?(@set) && @set&.vm_attrs
+     profile_fc = @set.vm_attrs['full_clone'] || @set.vm_attrs[:full_clone]
+     f.object.full_clone = profile_fc unless profile_fc.nil?
+   end %>
+
 <%
   vm_attrs = object_to_attributes_hash(f.object, from_profile, checked)
 

--- a/test/factories/foreman_fog_proxmox/proxmox_container_mock_factory.rb
+++ b/test/factories/foreman_fog_proxmox/proxmox_container_mock_factory.rb
@@ -44,11 +44,8 @@ module ForemanFogProxmox
       }
     end
 
-    def mock_container_vm
-      interface = mock('interface')
-      interface.stubs(:attributes).returns(mock_container_interface_attributes)
-      interfaces = [interface]
-      volume_attributes = {
+    def mock_container_volume_attributes
+      {
         id: 'rootfs',
         volid: 'local-lvm:vm-100-disk-1',
         size: 8,
@@ -63,6 +60,13 @@ module ForemanFogProxmox
         backup: nil,
         aio: nil,
       }
+    end
+
+    def mock_container_vm
+      interface = mock('interface')
+      interface.stubs(:attributes).returns(mock_container_interface_attributes)
+      interfaces = [interface]
+      volume_attributes = mock_container_volume_attributes
       volume = mock('volume')
       volume.stubs(:attributes).returns(volume_attributes)
       volumes = [volume]
@@ -142,6 +146,7 @@ module ForemanFogProxmox
       }
       vm.stubs(:attributes).returns(vm_attributes)
       vm.stubs(:container?).returns(true)
+      vm.stubs(:full_clone).returns(nil)
       [vm, config_attributes, volume_attributes, mock_container_interface_attributes]
     end
   end

--- a/test/factories/foreman_fog_proxmox/proxmox_server_mock_factory.rb
+++ b/test/factories/foreman_fog_proxmox/proxmox_server_mock_factory.rb
@@ -137,6 +137,7 @@ module ForemanFogProxmox
       }
       vm.stubs(:attributes).returns(vm_attributes)
       vm.stubs(:container?).returns(false)
+      vm.stubs(:full_clone).returns(nil)
       [vm, config_attributes, volume_attributes, mock_server_interface_attributes]
     end
   end

--- a/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
@@ -201,6 +201,26 @@ module ForemanFogProxmox
         assert_equal '0', vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:dhcp]
         assert_equal '0', vm_attrs[:interfaces_attributes]['0'][:compute_attributes][:dhcp6]
       end
+
+      it 'uses provisioning_full_clone fallback when vm.full_clone is nil' do
+        vm, = mock_server_vm
+        @cr.instance_variable_set(:@provisioning_full_clone, '1')
+        vm_attrs = @cr.vm_compute_attributes(vm)
+        assert_equal '1', vm_attrs[:full_clone]
+      end
+
+      it 'uses vm.full_clone directly when present' do
+        vm, = mock_server_vm
+        vm.stubs(:full_clone).returns('1')
+        vm_attrs = @cr.vm_compute_attributes(vm)
+        assert_equal '1', vm_attrs[:full_clone]
+      end
+
+      it 'omits full_clone from attrs when both vm.full_clone and provisioning_full_clone are nil' do
+        vm, = mock_server_vm
+        vm_attrs = @cr.vm_compute_attributes(vm)
+        assert_not vm_attrs.key?(:full_clone)
+      end
     end
   end
 end

--- a/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
@@ -30,19 +30,26 @@ module ForemanFogProxmox
         @image_id = @cr.id.to_s + '_' + 100.to_s
         @vmid = 101
         @image = mock('vm')
-        @image.expects(:clone)
         @cr.stubs(:find_vm_by_uuid).with(@image_id).returns(@image)
         @clone = mock('vm')
       end
       it 'clones server from image' do
+        @image.expects(:clone).with(@vmid, {})
         @clone.stubs(:container?).returns(false)
         @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
         @cr.clone_from_image(@image_id, @vmid)
       end
       it 'clones container from image' do
+        @image.expects(:clone).with(@vmid, {})
         @clone.stubs(:container?).returns(true)
         @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
         @cr.clone_from_image(@image_id, @vmid)
+      end
+      it 'full clones server from image' do
+        @image.expects(:clone).with(@vmid, { full: 1 })
+        @clone.stubs(:container?).returns(false)
+        @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
+        @cr.clone_from_image(@image_id, @vmid, full_clone: true)
       end
     end
   end

--- a/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
@@ -29,15 +29,25 @@ module ForemanFogProxmox
         @cr = FactoryBot.build_stubbed(:proxmox_cr)
         @vmid = 101
         @image = mock('vm', identity: '100')
-        @image.expects(:clone)
         @clone = mock('vm')
       end
-      it 'clones server from image' do
+
+      it 'clones server from image with linked clone (default)' do
+        @image.expects(:clone).with(@vmid, {})
         @clone.stubs(:container?).returns(false)
         @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
         @cr.clone_from_image(@image, @vmid)
       end
+
+      it 'clones server from image with full clone' do
+        @image.expects(:clone).with(@vmid, { full: 1 })
+        @clone.stubs(:container?).returns(false)
+        @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
+        @cr.clone_from_image(@image, @vmid, full_clone: true)
+      end
+
       it 'clones container from image' do
+        @image.expects(:clone).with(@vmid, {})
         @clone.stubs(:container?).returns(true)
         @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
         @cr.clone_from_image(@image, @vmid)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
@@ -299,7 +299,8 @@ module ForemanFogProxmox
         containers = mock('containers')
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
         vm = mock('vm')
-        cr.expects(:clone_from_image).with('999', 100).returns(vm)
+        cr.expects(:clone_from_image).with('999', 100, full_clone: false).returns(vm)
+        vm.expects(:full_clone=).with('0')
         vm.expects(:container?).returns(true)
         expected_args = { :vmid => "100", :type => "lxc" }
         cr.stubs(:parse_typed_vm).with(args, 'lxc').returns(expected_args)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
@@ -301,7 +301,8 @@ module ForemanFogProxmox
         vm = mock('vm')
         image = mock('image')
         cr.stubs(:find_vm_by_uuid).with('999').returns(image)
-        cr.expects(:clone_from_image).with(image, 100).returns(vm)
+        cr.expects(:clone_from_image).with(image, 100, full_clone: false).returns(vm)
+        vm.expects(:full_clone=).with('0')
         vm.expects(:container?).returns(true)
         expected_args = { :vmid => "100", :type => "lxc" }
         cr.stubs(:parse_typed_vm).with(args, 'lxc').returns(expected_args)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -103,7 +103,24 @@ module ForemanFogProxmox
         servers.stubs(:id_valid?).returns(true)
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
         vm = mock('vm')
-        cr.expects(:clone_from_image).with('999', 100).returns(vm)
+        cr.expects(:clone_from_image).with('999', 100, full_clone: false).returns(vm)
+        vm.expects(:full_clone=).with('0')
+        vm.expects(:container?).returns(false)
+        expected_args = { :vmid => "100", :type => "qemu", :name => "name" }
+        cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(expected_args)
+        vm.expects(:update).with(expected_args)
+        cr.create_vm(args)
+      end
+
+      it 'clones server with full clone' do
+        args = { vmid: '100', type: 'qemu', image_id: '999', name: 'name', full_clone: '1' }
+        servers = mock('servers')
+        containers = mock('containers')
+        servers.stubs(:id_valid?).returns(true)
+        cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
+        vm = mock('vm')
+        cr.expects(:clone_from_image).with('999', 100, full_clone: true).returns(vm)
+        vm.expects(:full_clone=).with('1')
         vm.expects(:container?).returns(false)
         expected_args = { :vmid => "100", :type => "qemu", :name => "name" }
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(expected_args)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -122,7 +122,26 @@ module ForemanFogProxmox
         vm = mock('vm')
         image = mock('image', config: mock('config', disks: []))
         cr.stubs(:find_vm_by_uuid).with('999').returns(image)
-        cr.expects(:clone_from_image).with(image, 100).returns(vm)
+        cr.expects(:clone_from_image).with(image, 100, full_clone: false).returns(vm)
+        vm.expects(:full_clone=).with('0')
+        vm.expects(:container?).returns(false)
+        expected_args = { :vmid => "100", :type => "qemu", :name => "name" }
+        cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(expected_args)
+        vm.expects(:update).with(expected_args)
+        cr.create_vm(args)
+      end
+
+      it 'clones server with full clone' do
+        args = { vmid: '100', type: 'qemu', image_id: '999', name: 'name', full_clone: '1' }
+        servers = mock('servers')
+        containers = mock('containers')
+        servers.stubs(:id_valid?).returns(true)
+        cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
+        vm = mock('vm')
+        image = mock('image', config: mock('config', disks: []))
+        cr.stubs(:find_vm_by_uuid).with('999').returns(image)
+        cr.expects(:clone_from_image).with(image, 100, full_clone: true).returns(vm)
+        vm.expects(:full_clone=).with('1')
         vm.expects(:container?).returns(false)
         expected_args = { :vmid => "100", :type => "qemu", :name => "name" }
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(expected_args)

--- a/webpack/components/GeneralTabContent.js
+++ b/webpack/components/GeneralTabContent.js
@@ -13,6 +13,7 @@ const GeneralTabContent = ({
   imagesMap,
   handleChange,
   untemplatable,
+  provisionMethodState,
 }) => (
   <PageSection padding={{ default: 'noPadding' }}>
     <Divider component="li" style={{ marginBottom: '2rem' }} />
@@ -75,6 +76,18 @@ const GeneralTabContent = ({
       />
     )}
     <InputField
+      name={general?.fullClone?.name}
+      label={__('Full clone')}
+      info={__(
+        'Clone the full disk instead of a linked clone. Required during image-based provisioning for storages that do not support linked clones, e.g. LVM.'
+      )}
+      type="checkbox"
+      value={general?.fullClone?.value}
+      checked={String(general?.fullClone?.value) === '1'}
+      disabled={!fromProfile && (!newVm || provisionMethodState !== 'image')}
+      onChange={handleChange}
+    />
+    <InputField
       name={general?.description?.name}
       label={__('Description')}
       type="textarea"
@@ -93,6 +106,7 @@ GeneralTabContent.propTypes = {
   imagesMap: PropTypes.array,
   handleChange: PropTypes.func.isRequired,
   untemplatable: PropTypes.bool,
+  provisionMethodState: PropTypes.string,
 };
 
 GeneralTabContent.defaultProps = {
@@ -102,6 +116,7 @@ GeneralTabContent.defaultProps = {
   poolsMap: [],
   imagesMap: [],
   untemplatable: false,
+  provisionMethodState: 'build',
 };
 
 export default GeneralTabContent;

--- a/webpack/components/GeneralTabContent.js
+++ b/webpack/components/GeneralTabContent.js
@@ -13,6 +13,7 @@ const GeneralTabContent = ({
   imagesMap,
   handleChange,
   untemplatable,
+  provisionMethodState,
 }) => (
   <PageSection padding={{ default: 'noPadding' }}>
     <Divider component="li" style={{ marginBottom: '2rem' }} />
@@ -74,6 +75,20 @@ const GeneralTabContent = ({
         onChange={handleChange}
       />
     )}
+    {(fromProfile || newVm) && (
+      <InputField
+        name={general?.fullClone?.name}
+        label={__('Full clone')}
+        info={__(
+          'Clone the full disk instead of a linked clone. Required during image-based provisioning for storages that do not support linked clones, e.g. LVM.'
+        )}
+        type="checkbox"
+        value={general?.fullClone?.value}
+        checked={String(general?.fullClone?.value) === '1'}
+        disabled={!fromProfile && provisionMethodState !== 'image'}
+        onChange={handleChange}
+      />
+    )}
     <InputField
       name={general?.description?.name}
       label={__('Description')}
@@ -93,6 +108,7 @@ GeneralTabContent.propTypes = {
   imagesMap: PropTypes.array,
   handleChange: PropTypes.func.isRequired,
   untemplatable: PropTypes.bool,
+  provisionMethodState: PropTypes.string,
 };
 
 GeneralTabContent.defaultProps = {
@@ -102,6 +118,7 @@ GeneralTabContent.defaultProps = {
   poolsMap: [],
   imagesMap: [],
   untemplatable: false,
+  provisionMethodState: 'build',
 };
 
 export default GeneralTabContent;

--- a/webpack/components/ProxmoxVmType.js
+++ b/webpack/components/ProxmoxVmType.js
@@ -351,6 +351,7 @@ const ProxmoxVmType = ({
               imagesMap={imagesMap}
               handleChange={handleChange}
               untemplatable={untemplatable}
+              provisionMethodState={provisionMethodState}
             />
           </Tab>
 

--- a/webpack/components/ProxmoxVmType.js
+++ b/webpack/components/ProxmoxVmType.js
@@ -373,6 +373,7 @@ const ProxmoxVmType = ({
               imagesMap={imagesMap}
               handleChange={handleChange}
               untemplatable={untemplatable}
+              provisionMethodState={provisionMethodState}
             />
           </Tab>
 

--- a/webpack/components/__tests__/GeneralTabContent.test.js
+++ b/webpack/components/__tests__/GeneralTabContent.test.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GeneralTabContent from '../GeneralTabContent';
+
+const baseGeneral = {
+  vmid: { name: 'host[compute_attributes][vmid]', value: '100' },
+  nodeId: { name: 'host[compute_attributes][node_id]', value: 'node1' },
+  pool: { name: 'host[compute_attributes][pool]', value: '' },
+  startAfterCreate: {
+    name: 'host[compute_attributes][start_after_create]',
+    value: '0',
+  },
+  templated: { name: 'host[compute_attributes][templated]', value: '0' },
+  imageId: { name: 'compute_attribute[vm_attrs][image_id]', value: '' },
+  fullClone: { name: 'compute_attribute[vm_attrs][full_clone]', value: '0' },
+  description: { name: 'host[compute_attributes][description]', value: '' },
+};
+
+describe('GeneralTabContent', () => {
+  it('shows the Full clone checkbox when configuring a compute profile', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={baseGeneral}
+        fromProfile
+        handleChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Full clone')).toBeInTheDocument();
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('checks the Full clone checkbox when full_clone is set', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={{
+          ...baseGeneral,
+          fullClone: { ...baseGeneral.fullClone, value: '1' },
+        }}
+        fromProfile
+        handleChange={jest.fn()}
+      />
+    );
+
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).toBeChecked();
+  });
+
+  it('shows the Full clone checkbox enabled when creating a new host with image provisioning', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={baseGeneral}
+        fromProfile={false}
+        newVm
+        provisionMethodState="image"
+        handleChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Full clone')).toBeInTheDocument();
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).not.toBeDisabled();
+  });
+
+  it('shows the Full clone checkbox disabled when creating a new host with network provisioning', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={baseGeneral}
+        fromProfile={false}
+        newVm
+        provisionMethodState="build"
+        handleChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Full clone')).toBeInTheDocument();
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).toBeDisabled();
+  });
+
+  it('shows the Full clone checkbox as disabled when editing an existing host', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={baseGeneral}
+        fromProfile={false}
+        newVm={false}
+        handleChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Full clone')).toBeInTheDocument();
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).toBeDisabled();
+  });
+});

--- a/webpack/components/__tests__/GeneralTabContent.test.js
+++ b/webpack/components/__tests__/GeneralTabContent.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GeneralTabContent from '../GeneralTabContent';
+
+const baseGeneral = {
+  vmid: { name: 'host[compute_attributes][vmid]', value: '100' },
+  nodeId: { name: 'host[compute_attributes][node_id]', value: 'node1' },
+  pool: { name: 'host[compute_attributes][pool]', value: '' },
+  startAfterCreate: {
+    name: 'host[compute_attributes][start_after_create]',
+    value: '0',
+  },
+  templated: { name: 'host[compute_attributes][templated]', value: '0' },
+  imageId: { name: 'compute_attribute[vm_attrs][image_id]', value: '' },
+  fullClone: { name: 'compute_attribute[vm_attrs][full_clone]', value: '0' },
+  description: { name: 'host[compute_attributes][description]', value: '' },
+};
+
+describe('GeneralTabContent', () => {
+  it('shows the Full clone checkbox when configuring a compute profile', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={baseGeneral}
+        fromProfile
+        handleChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Full clone')).toBeInTheDocument();
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('checks the Full clone checkbox when full_clone is set', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={{
+          ...baseGeneral,
+          fullClone: { ...baseGeneral.fullClone, value: '1' },
+        }}
+        fromProfile
+        handleChange={jest.fn()}
+      />
+    );
+
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).toBeChecked();
+  });
+
+  it('shows the Full clone checkbox enabled when creating a new host with image provisioning', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={baseGeneral}
+        fromProfile={false}
+        newVm
+        provisionMethodState="image"
+        handleChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Full clone')).toBeInTheDocument();
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).not.toBeDisabled();
+  });
+
+  it('shows the Full clone checkbox disabled when creating a new host with network provisioning', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={baseGeneral}
+        fromProfile={false}
+        newVm
+        provisionMethodState="build"
+        handleChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Full clone')).toBeInTheDocument();
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).toBeDisabled();
+  });
+
+  it('hides the Full clone checkbox when editing an existing host', () => {
+    const { container } = render(
+      <GeneralTabContent
+        general={baseGeneral}
+        fromProfile={false}
+        newVm={false}
+        handleChange={jest.fn()}
+      />
+    );
+
+    const checkbox = container.querySelector(
+      'input[name="compute_attribute[vm_attrs][full_clone]"]'
+    );
+    expect(checkbox).toBeNull();
+  });
+});


### PR DESCRIPTION
Proxmox rejects linked clones when the template disk lives on storage that doesn't support them (e.g. plain LVM), failing VM creation with "Linked clone feature is not supported". Add a "Full clone" checkbox to the compute profile so clone_from_image can pass full=1 to the Proxmox clone API in that case.

for a temporary live patch on my side I was able to hardcode image.clone(vmid, full: 1) in clone_from_image in proxmox_images.rb

I used Claude to help with this entire thing to help me learn about the code base and provide an understanding first. I then was able to figure out the frontend stuff and used AI to write tests, and improve upon what i originally wrote to make it look clean and up to standards. Please let me know if this is unacceptable and ill take this away. 

<img width="2622" height="1345" alt="image" src="https://github.com/user-attachments/assets/44572ff7-0853-4636-ba91-4e5debad8bcc" />

<img width="1001" height="590" alt="image" src="https://github.com/user-attachments/assets/93cf303f-0627-4c6f-a39c-547ae325dd75" />

Fixes #492 