### PR TITLE
Add SSH public key authentication for Proxmox SSH operations

### DIFF
--- a/app/assets/javascripts/foreman_fog_proxmox/proxmox_compute_resource.js
+++ b/app/assets/javascripts/foreman_fog_proxmox/proxmox_compute_resource.js
@@ -18,6 +18,7 @@
 $(document).ready(function () {
   sslVerifyPeerSelected();
   authMethodSelected();
+  sshSelected();
 });
 
 function sslVerifyPeerSelected() {
@@ -56,15 +57,25 @@ function authMethods(){
 }
 
 function authMethodFieldsetId(method){
-  return '#compute_ressource_' + method + '_field_set';
+  return '#compute_resource_' + method + '_field_set';
 }
 
 function authMethodSelected() {
   var selected = $("#compute_resource_auth_method").val();
-  console.log("auth_method="+selected);
   authMethods().forEach(function(method){
     toggleFieldset(method, selected);
   });
+}
+
+function sshSelected() {
+  var checkbox = $('#compute_resource_enable_ssh');
+  if (!checkbox.length) return;
+
+  var selected = checkbox.is(':checked');
+  var sshFields = $('#compute_resource_ssh_field_set .proxmox-ssh-field');
+
+  sshFields.toggleClass('hide', !selected).toggle(selected);
+  sshFields.find('input, textarea').prop('disabled', !selected);
 }
 
 window.tfm = window.tfm || {};
@@ -72,4 +83,5 @@ window.tfm.computeResource = window.tfm.computeResource || {};
 window.tfm.computeResource.proxmox = {
   authMethodSelected: authMethodSelected,
   sslVerifyPeerSelected: sslVerifyPeerSelected,
+  sshSelected: sshSelected,
 };

--- a/app/controllers/concerns/foreman_fog_proxmox/controller/parameters/compute_resource.rb
+++ b/app/controllers/concerns/foreman_fog_proxmox/controller/parameters/compute_resource.rb
@@ -28,7 +28,7 @@ module ForemanFogProxmox
             super.tap do |filter|
               filter.permit :ssl_verify_peer,
                 :ssl_certs, :disable_proxy, :auth_method, :token_id, :token,
-                :caching_enabled
+                :caching_enabled, :enable_ssh, :ssh_username
             end
           end
 

--- a/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
+++ b/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
@@ -106,6 +106,17 @@ module ForemanFogProxmox
       }
     end
 
+    # GET foreman_fog_proxmox/compute_resources/:compute_resource_id/ssh_configuration
+    def ssh_configuration
+      cr = ComputeResource.authorized(:view_compute_resources).find(params[:compute_resource_id])
+
+      render json: {
+        enabled: cr.enable_ssh,
+        username: cr.ssh_username,
+        public_key: cr.key_pair&.public,
+      }
+    end
+
     private
 
     def extract_nodes(compute_resource)

--- a/app/helpers/proxmox_vm_cloudinit_helper.rb
+++ b/app/helpers/proxmox_vm_cloudinit_helper.rb
@@ -89,7 +89,7 @@ module ProxmoxVMCloudinitHelper
     user_data = args.delete(:user_data)
     return args if user_data == ''
     check_template_format(user_data)
-    ssh = vm_ssh
+    ssh = vm_ssh(args[:node_id])
 
     if user_data.include?('#network-config') && user_data.include?('#cloud-config')
       config_data.concat(user_data.split('#network-config'))
@@ -112,7 +112,11 @@ module ProxmoxVMCloudinitHelper
 
   def attach_cloudinit_iso(node, iso)
     volume = nil
-    storages(node, 'iso').each do |storage|
+    iso_storages = storages(node, 'iso')
+
+    raise ::Foreman::Exception, "No storage supporting ISO content was found for node #{node}" if iso_storages.empty?
+
+    iso_storages.each do |storage|
       volume = storage.volumes.detect { |v| v.volid.include? File.basename(iso) }
       break if volume
     end
@@ -133,12 +137,48 @@ module ProxmoxVMCloudinitHelper
     { boot: "order=" + disks }
   end
 
-  def vm_ssh
-    ssh = Fog::SSH.new(URI.parse(fog_credentials[:proxmox_url]).host, fog_credentials[:proxmox_username].split('@')[0], { password: fog_credentials[:proxmox_password] })
+  def vm_ssh(node_id)
+    username, options = ssh_credentials
+    node = client.nodes.get(node_id)
+    raise ::Foreman::Exception, "Proxmox node #{node_id} was not found" unless node
+
+    host = proxmox_ssh_host(node)
+    ssh = Fog::SSH.new(host, username, options)
     ssh.run('ls') # test if ssh is successful
     ssh
+  rescue ::Foreman::Exception
+    raise
   rescue StandardError => e
     raise ::Foreman::Exception, "Unable to ssh into proxmox server: #{e}"
+  end
+
+  def proxmox_ssh_host(node)
+    cluster_ip = proxmox_cluster_node_ip(node.node)
+    return cluster_ip if cluster_ip.present?
+
+    raise ::Foreman::Exception,
+      "Unable to determine an SSH address for Proxmox node #{node.node}. " \
+      "Ensure /cluster/status reports its IP address."
+  end
+
+  def proxmox_cluster_node_ip(node_name)
+    cluster_node = Array(client.cluster_status).find do |entry|
+      type = entry['type'] || entry[:type]
+      name = entry['name'] || entry[:name]
+      type == 'node' && name == node_name
+    end
+    cluster_node && (cluster_node['ip'] || cluster_node[:ip])
+  rescue StandardError => e
+    logger.warn("Could not retrieve Proxmox cluster status while resolving node #{node_name}: #{e}")
+    nil
+  end
+
+  def ssh_credentials
+    if enable_ssh && ssh_username.present? && key_pair&.secret.present?
+      [ssh_username, { key_data: [key_pair.secret] }]
+    else
+      [fog_credentials[:proxmox_username].split('@')[0], { password: fog_credentials[:proxmox_password] }]
+    end
   end
 
   def check_template_format(user_data)

--- a/app/models/foreman_fog_proxmox/proxmox.rb
+++ b/app/models/foreman_fog_proxmox/proxmox.rb
@@ -23,6 +23,8 @@ require 'foreman_fog_proxmox/value'
 
 module ForemanFogProxmox
   class Proxmox < ComputeResource
+    PROXMOX_SSH_KEY_BITS = 4096
+
     include ProxmoxVMHelper
     include ProxmoxConnection
     include ProxmoxVMNew
@@ -37,6 +39,10 @@ module ForemanFogProxmox
     include ProxmoxConsole
     include ComputeAttributesUpdateDetector
     include ComputeResourceCaching
+
+    has_one :key_pair, :foreign_key => :compute_resource_id, :dependent => :destroy, :inverse_of => :compute_resource
+    after_create :setup_key_pair
+    after_destroy :destroy_key_pair
 
     validates :url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :presence => true
     validates :auth_method, :presence => true, :inclusion => { in: ['access_ticket', 'user_token'],
@@ -129,6 +135,23 @@ module ForemanFogProxmox
       attrs[:token] = value
     end
 
+    def ssh_username
+      attrs[:ssh_username]
+    end
+
+    def ssh_username=(value)
+      attrs[:ssh_username] = value
+    end
+
+    def enable_ssh
+      value = attrs.with_indifferent_access[:enable_ssh]
+      value.nil? ? key_pair.present? : Foreman::Cast.to_bool(value)
+    end
+
+    def enable_ssh=(value)
+      attrs[:enable_ssh] = value
+    end
+
     private
 
     def structs_from_cache(items)
@@ -137,6 +160,38 @@ module ForemanFogProxmox
 
     def extract_attributes(resource, fields)
       slice_vm_attributes(fields.index_with { |field| resource.try(field) }, fields)
+    end
+
+    def setup_key_pair
+      return true unless enable_ssh
+
+      key = OpenSSL::PKey::RSA.generate(PROXMOX_SSH_KEY_BITS)
+      KeyPair.create!(
+        name: "foreman-#{id}#{Foreman.uuid}",
+        compute_resource_id: id,
+        secret: key.private_to_pem,
+        public: "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
+      )
+    rescue StandardError => e
+      Foreman::Logging.exception('Failed to generate key pair', e)
+      destroy_key_pair
+      raise
+    end
+
+    def destroy_key_pair
+      return true if key_pair.blank?
+
+      key_pair.delete
+
+      true
+    rescue StandardError => e
+      Foreman::Logging.exception(
+        "Failed to delete local key pair for #{provider_friendly_name}: #{name}",
+        e,
+        level: :warn
+      )
+
+      true
     end
 
     def fog_credentials

--- a/app/views/compute_resources/form/_proxmox.html.erb
+++ b/app/views/compute_resources/form/_proxmox.html.erb
@@ -18,19 +18,35 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
 <% user_token = f.object.auth_method == 'user_token' %>
 <% access_ticket = f.object.auth_method == 'access_ticket' %>
 <% ssl_verify_peer = f.object.ssl_verify_peer %>
+<% enable_ssh = f.object.enable_ssh %>
+<% show_ssh_fields = f.object.new_record? || enable_ssh %>
+<% ssh_public_key = f.object.key_pair.try(:public) if f.object.persisted? %>
 <%= select_f f, :auth_method, proxmox_auth_methods_map, :id, :name, { }, :label_help => _("Click Test connection button before changing it"), :label => _('Authentication method'), :label_size => "col-md-2", :required => true, :onchange => 'tfm.computeResource.proxmox.authMethodSelected();' %>
-<%= field_set_tag _("Common fields"), :id => "compute_ressource_common_field_set" do %>
+<%= field_set_tag _("Common fields"), :id => "compute_resource_common_field_set" do %>
   <%= text_f f, :url, :help_block => _("e.g. https://127.0.0.1:8006/api2/json") %>
   <%= text_f f, :user , :help_block => _("e.g. root@pam") %>
 <% end %>
-<%= field_set_tag _("User token fields"), :id => "compute_ressource_user_token_field_set", :class => ('hide' unless user_token), :disabled => !user_token do %>
+<% if show_ssh_fields %>
+  <%= field_set_tag _("SSH fields"), :id => "compute_resource_ssh_field_set" do %>
+    <% if f.object.new_record? %>
+      <%= checkbox_f f, :enable_ssh, :label => _("Enable SSH"), :label_help => _("Used by Foreman for SSH operations on the Proxmox host during image-based deployment."), :checked_value => '1', :onchange => 'tfm.computeResource.proxmox.sshSelected();' %>
+    <% end %>
+    <%= text_f f, :ssh_username, :label => _('SSH username'), :readonly => f.object.persisted?, :wrapper_class => "form-group proxmox-ssh-field #{'hide' unless enable_ssh}" %>
+    <% if enable_ssh && ssh_public_key.present? %>
+      <%= field(f, :ssh_public_key, :label => _('SSH public key'), :label_help => _('Copy this public key to ~/.ssh/authorized_keys of the configured SSH user on the Proxmox server to enable SSH key authentication.'), :size => "col-md-8", :wrapper_class => "form-group proxmox-ssh-field") do %>
+        <%= content_tag(:textarea, ssh_public_key, :class => "form-control", :rows => 4, :readonly => true) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+<%= field_set_tag _("User token fields"), :id => "compute_resource_user_token_field_set", :class => ('hide' unless user_token), :disabled => !user_token do %>
   <%= text_f f, :token_id, :label => _('User token id'), :required => user_token %>
   <%= text_f f, :token, :label => _('User token value'), :required => user_token, :label_help => _("Click Test connection button to check token") %>
 <% end %>
-<%= field_set_tag _("Access ticket fields"), :id => "compute_ressource_access_ticket_field_set", :class => ('hide' unless access_ticket), :disabled => !access_ticket do %>
+<%= field_set_tag _("Access ticket fields"), :id => "compute_resource_access_ticket_field_set", :class => ('hide' unless access_ticket), :disabled => !access_ticket do %>
   <%= password_f f, :password, :keep_value => true, :unset => unset_password?, :required => access_ticket %>
 <% end %>
-<%= field_set_tag _("SSL fields"), :id => "compute_ressource_ssl_field_set" do %>  
+<%= field_set_tag _("SSL fields"), :id => "compute_resource_ssl_field_set" do %>  
   <%= checkbox_f f, :ssl_verify_peer, :label => _("SSL verify peer"), :label_help => _("Click Test connection button before changing it"), :checked_value => '1', :onchange => 'tfm.computeResource.proxmox.sslVerifyPeerSelected();' %>
   <%= textarea_f f, :ssl_certs, :label => _("X509 Certification Authorities"), :size => "col-md-4",
     :wrapper_class => "form-group #{'hide' unless ssl_verify_peer}",

--- a/app/views/compute_resources/show/_proxmox.html.erb
+++ b/app/views/compute_resources/show/_proxmox.html.erb
@@ -32,6 +32,16 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <td><%= @compute_resource.auth_method %></td>
 </tr>
 <tr>
+  <td><%= _("SSH Authentication") %></td>
+  <td><%= @compute_resource.enable_ssh ? _("Enabled") : _("Disabled") %></td>
+</tr>
+<% if @compute_resource.enable_ssh %>
+  <tr>
+    <td><%= _("SSH Username") %></td>
+    <td><%= @compute_resource.ssh_username %></td>
+  </tr>
+<% end %>
+<tr>
   <td><%= _("Caching") %></td>
   <td><%= @compute_resource.caching_enabled ? _("Enabled") : _("Disabled") %></td>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,5 +36,8 @@ Rails.application.routes.draw do
     match 'metadata/:compute_resource_id',
       :to => 'compute_resources#metadata',
       :via => 'get'
+    match 'compute_resources/:compute_resource_id/ssh_configuration',
+      :to => 'compute_resources#ssh_configuration',
+      :via => 'get'
   end
 end

--- a/lib/foreman_fog_proxmox/engine.rb
+++ b/lib/foreman_fog_proxmox/engine.rb
@@ -53,7 +53,8 @@ module ForemanFogProxmox
                               foreman_fog_proxmox/compute_resources/iso_storages_by_id_and_node
                               foreman_fog_proxmox/compute_resources/bridges_by_id_and_node
                               foreman_fog_proxmox/compute_resources/volumes_by_node_and_storage
-                              foreman_fog_proxmox/compute_resources/metadata])
+                              foreman_fog_proxmox/compute_resources/metadata
+                              foreman_fog_proxmox/compute_resources/ssh_configuration])
           p.actions.uniq!
 
           security_block :foreman_fog_proxmox do

--- a/test/functional/compute_resources_controller_test.rb
+++ b/test/functional/compute_resources_controller_test.rb
@@ -106,5 +106,52 @@ module ForemanFogProxmox
       assert_instance_of Array, json_response['storages']
       assert_instance_of Array, json_response['bridges']
     end
+
+    test 'should get SSH configuration without exposing private key' do
+      authorized_resources = mock('authorized_resources')
+      ComputeResource.expects(:authorized).with(:view_compute_resources).returns(authorized_resources)
+      authorized_resources.expects(:find).with(@compute_resource.id.to_s).returns(@compute_resource)
+      @compute_resource.stubs(:enable_ssh).returns(true)
+      @compute_resource.stubs(:ssh_username).returns('foreman')
+      @compute_resource.stubs(:key_pair).returns(stub(public: 'ssh-rsa PUBLIC KEY', secret: 'PRIVATE KEY'))
+
+      get :ssh_configuration,
+        params: { :compute_resource_id => @compute_resource.id },
+        session: set_session_user
+
+      assert_response :success
+      assert_equal(
+        {
+          'enabled' => true,
+          'username' => 'foreman',
+          'public_key' => 'ssh-rsa PUBLIC KEY',
+        },
+        JSON.parse(@response.body)
+      )
+      assert_not_includes @response.body, 'PRIVATE KEY'
+    end
+
+    test 'should return empty SSH details when SSH is disabled' do
+      authorized_resources = mock('authorized_resources')
+      ComputeResource.expects(:authorized).with(:view_compute_resources).returns(authorized_resources)
+      authorized_resources.expects(:find).with(@compute_resource.id.to_s).returns(@compute_resource)
+      @compute_resource.stubs(:enable_ssh).returns(false)
+      @compute_resource.stubs(:ssh_username).returns(nil)
+      @compute_resource.stubs(:key_pair).returns(nil)
+
+      get :ssh_configuration,
+        params: { :compute_resource_id => @compute_resource.id },
+        session: set_session_user
+
+      assert_response :success
+      assert_equal(
+        {
+          'enabled' => false,
+          'username' => nil,
+          'public_key' => nil,
+        },
+        JSON.parse(@response.body)
+      )
+    end
   end
 end

--- a/test/unit/foreman_fog_proxmox/proxmox_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_test.rb
@@ -39,6 +39,44 @@ module ForemanFogProxmox
     should_not allow_value('root').for(:user)
     should_not allow_value('a').for(:url)
     should allow_values('http://foo.com', 'http://bar.com/baz').for(:url)
+    should have_one(:key_pair).with_foreign_key('compute_resource_id').dependent(:destroy)
+
+    test 'does not advertise remote key_pair capability' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr)
+
+      assert_not_includes cr.capabilities, :key_pair
+    end
+
+    test 'does not create a local KeyPair when SSH is disabled' do
+      assert_no_difference('KeyPair.count') do
+        @compute_resource = FactoryBot.create(:proxmox_cr)
+      end
+
+      assert_nil @compute_resource.key_pair
+    end
+
+    test 'creates a local KeyPair with private and public keys when SSH is enabled' do
+      assert_difference('KeyPair.count') do
+        @compute_resource = FactoryBot.create(:proxmox_cr, enable_ssh: true)
+      end
+
+      key_pair = @compute_resource.key_pair
+
+      assert_not_nil key_pair
+      assert key_pair.secret.starts_with?('-----BEGIN')
+      assert key_pair.public.starts_with?('ssh-rsa ')
+    end
+
+    test 'removes the key pair when the compute resource is deleted' do
+      compute_resource = FactoryBot.create(:proxmox_cr, enable_ssh: true)
+      key_pair = compute_resource.key_pair
+
+      assert_difference('KeyPair.count', -1) do
+        compute_resource.destroy!
+      end
+
+      assert_not KeyPair.exists?(key_pair.id)
+    end
 
     test '#associated_host matches any NIC' do
       mac = 'ca:d0:e6:32:16:97'
@@ -52,6 +90,138 @@ module ForemanFogProxmox
       cr = FactoryBot.build_stubbed(:proxmox_cr)
 
       assert_equal :foreman_uuid, cr.provided_attributes[:uuid]
+    end
+
+    test 'uses key authentication when ssh is enabled' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr, enable_ssh: true, ssh_username: 'foreman')
+      cr.stubs(:key_pair).returns(stub(secret: 'PRIVATE KEY'))
+      node = stub(node: 'proxmox-node-1')
+      nodes = stub
+      nodes.stubs(:get).with('proxmox-node-1').returns(node)
+      client = stub(nodes: nodes)
+      client.stubs(:cluster_status).returns(
+        [{ 'name' => 'proxmox-node-1', 'ip' => '192.168.56.101', 'type' => 'node' }]
+      )
+      cr.stubs(:client).returns(client)
+      ssh = mock('ssh')
+
+      Fog::SSH.expects(:new).with(
+        '192.168.56.101',
+        'foreman',
+        { key_data: ['PRIVATE KEY'] }
+      ).returns(ssh)
+      ssh.expects(:run).with('ls')
+
+      assert_equal ssh, cr.vm_ssh('proxmox-node-1')
+    end
+
+    test 'uses the matching node IP from cluster status' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr, enable_ssh: true, ssh_username: 'foreman')
+      cr.stubs(:key_pair).returns(stub(secret: 'PRIVATE KEY'))
+      node = stub(node: 'proxmox-noris')
+      nodes = stub
+      nodes.stubs(:get).with('proxmox-noris').returns(node)
+      client = stub(nodes: nodes)
+      client.expects(:cluster_status).returns(
+        [{ 'id' => 'node/proxmox-noris', 'name' => 'proxmox-noris', 'ip' => '192.168.56.102', 'type' => 'node' }]
+      )
+      cr.stubs(:client).returns(client)
+      ssh = mock('ssh')
+
+      Fog::SSH.expects(:new).with(
+        '192.168.56.102',
+        'foreman',
+        { key_data: ['PRIVATE KEY'] }
+      ).returns(ssh)
+      ssh.expects(:run).with('ls')
+
+      assert_equal ssh, cr.vm_ssh('proxmox-noris')
+    end
+
+    test 'reports an actionable error when the node has no cluster status IP' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr, enable_ssh: true, ssh_username: 'foreman')
+      cr.stubs(:key_pair).returns(stub(secret: 'PRIVATE KEY'))
+      node = stub(node: 'proxmox-noris')
+      nodes = stub
+      nodes.stubs(:get).with('proxmox-noris').returns(node)
+      client = stub(nodes: nodes)
+      client.expects(:cluster_status).returns(
+        [{ 'name' => 'proxmox-noris', 'type' => 'node' }]
+      )
+      cr.stubs(:client).returns(client)
+
+      error = assert_raises(::Foreman::Exception) do
+        cr.vm_ssh('proxmox-noris')
+      end
+
+      assert_equal(
+        'Unable to determine an SSH address for Proxmox node proxmox-noris. ' \
+        'Ensure /cluster/status reports its IP address.',
+        error.bare_message
+      )
+    end
+
+    test 'uses the VM node for SSH in a multi-node cluster' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr, enable_ssh: true, ssh_username: 'foreman')
+      cr.stubs(:key_pair).returns(stub(secret: 'PRIVATE KEY'))
+      vm = stub(node_id: 'proxmox-node-3')
+      node3 = stub(node: 'proxmox-node-3')
+      nodes = stub
+      nodes.expects(:get).with(vm.node_id).returns(node3)
+      client = stub(nodes: nodes)
+      client.expects(:cluster_status).returns(
+        (1..5).map do |index|
+          { 'id' => "node/proxmox-node-#{index}", 'name' => "proxmox-node-#{index}",
+            'ip' => "192.168.56.10#{index}", 'type' => 'node' }
+        end
+      )
+      cr.stubs(:client).returns(client)
+      ssh = mock('ssh')
+
+      Fog::SSH.expects(:new).with(
+        '192.168.56.103',
+        'foreman',
+        { key_data: ['PRIVATE KEY'] }
+      ).returns(ssh)
+      ssh.expects(:run).with('ls')
+
+      assert_equal ssh, cr.vm_ssh(vm.node_id)
+    end
+
+    test 'raises an exception when the VM node is not found' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr, enable_ssh: true, ssh_username: 'foreman')
+      cr.stubs(:key_pair).returns(stub(secret: 'PRIVATE KEY'))
+      nodes = stub
+      nodes.expects(:get).with('missing-node').returns(nil)
+      cr.stubs(:client).returns(stub(nodes: nodes))
+
+      error = assert_raises(::Foreman::Exception) do
+        cr.vm_ssh('missing-node')
+      end
+
+      assert_equal 'Proxmox node missing-node was not found', error.bare_message
+    end
+
+    test 'uses password authentication when ssh is disabled' do
+      cr = FactoryBot.build_stubbed(:proxmox_cr, enable_ssh: false)
+      node = stub(node: 'proxmox-node-1')
+      nodes = stub
+      nodes.stubs(:get).with('proxmox-node-1').returns(node)
+      client = stub(nodes: nodes)
+      client.stubs(:cluster_status).returns(
+        [{ 'name' => 'proxmox-node-1', 'ip' => '192.168.56.101', 'type' => 'node' }]
+      )
+      cr.stubs(:client).returns(client)
+      ssh = mock('ssh')
+
+      Fog::SSH.expects(:new).with(
+        '192.168.56.101',
+        'root',
+        { password: 'proxmox01' }
+      ).returns(ssh)
+      ssh.expects(:run).with('ls')
+
+      assert_equal ssh, cr.vm_ssh('proxmox-node-1')
     end
 
     test '#update_required? detects added HDD attributes' do

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -112,7 +112,6 @@ module ForemanFogProxmox
       end
 
       it 'attaches generated cloud-init ISO from a later ISO storage' do
-        cr = ForemanFogProxmox::Proxmox.new
         first_storage = mock('first_storage')
         second_storage = mock('second_storage')
         volume = mock('volume')
@@ -120,20 +119,19 @@ module ForemanFogProxmox
         first_storage.stubs(:volumes).returns([])
         volume.stubs(:volid).returns('local:iso/name_cloudinit.iso')
         second_storage.stubs(:volumes).returns([volume])
-        cr.stubs(:storages).with('proxmox', 'iso').returns([first_storage, second_storage])
+        cr = compute_resource_with_iso_storages([first_storage, second_storage])
 
         assert_equal({ ide2: 'local:iso/name_cloudinit.iso,media=cdrom' },
           cr.attach_cloudinit_iso('proxmox', '/var/lib/vz/template/iso/name_cloudinit.iso'))
       end
 
       it 'raises Foreman::Exception when generated cloud-init ISO is not on any ISO storage' do
-        cr = ForemanFogProxmox::Proxmox.new
         storage = mock('storage')
         other_volume = mock('other_volume')
 
         other_volume.stubs(:volid).returns('local:iso/other.iso')
         storage.stubs(:volumes).returns([other_volume])
-        cr.stubs(:storages).with('proxmox', 'iso').returns([storage])
+        cr = compute_resource_with_iso_storages([storage])
 
         err = assert_raises Foreman::Exception do
           cr.attach_cloudinit_iso('proxmox', '/var/lib/vz/template/iso/name_cloudinit.iso')
@@ -141,6 +139,24 @@ module ForemanFogProxmox
 
         assert err.message.end_with?('Could not find generated cloud-init ISO name_cloudinit.iso on any ISO storage for node proxmox')
       end
+
+      it 'raises Foreman::Exception when the node has no storage supporting ISO content' do
+        cr = compute_resource_with_iso_storages([])
+
+        err = assert_raises Foreman::Exception do
+          cr.attach_cloudinit_iso('proxmox', '/var/lib/vz/template/iso/name_cloudinit.iso')
+        end
+
+        assert err.message.end_with?('No storage supporting ISO content was found for node proxmox')
+      end
+    end
+
+    private
+
+    def compute_resource_with_iso_storages(storages)
+      cr = ForemanFogProxmox::Proxmox.new
+      cr.stubs(:storages).with('proxmox', 'iso').returns(storages)
+      cr
     end
   end
 end


### PR DESCRIPTION
- Added SSH configuration fields to the compute resource creation form.
- Stored the generated public and private keys in Foreman KeyPair records.
- Displayed the generated public key and SSH username in compute resource edit mode.
- Displayed SSH authentication status and SSH username on the compute resource details page.
- Preserved backward compatibility by continuing to use username/password authentication when SSH public key authentication is disabled.
- Fixed some typos.
- Added unit tests for the new SSH feature.
- Removed Foreman SSH Keys tab for Proxmox compute resources.
- Added a new endpoint exposing the SSH public key and SSH username for automation tests.
- Improved SSH host resolution for multi-node Proxmox clusters by resolving the VM's assigned node IP through the /cluster/status API instead of always using the default node.


Side notes:
- I reverted` client.nodes.get(node) `back to `storage('node', 'iso') `because it was introduced for caching and is expected that caching will be removed soon .
- For this PR a new endpoint has been added in fog-proxmox to expose the proxmox /cluster/status API [PR](https://github.com/fog/fog-proxmox/pull/134)
- Just ignore the pipeline for now. It’s failing because of the `no-magic-numbers` JavaScript lint rule 