### PR TITLE
Fix VMID handling when requested VMID is unavailable

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -36,8 +36,6 @@ module ForemanFogProxmox
       type = args[:type]
       node = client.nodes.get(args[:node_id])
       vmid = args[:vmid] = assign_vmid(args[:vmid].to_i, node)
-      raise ::Foreman::Exception, format(N_('invalid vmid=%<vmid>s'), vmid: vmid) unless node.servers.id_valid?(vmid)
-
       image_id = args[:image_id]
       remove_volume_keys(args)
       if image_id
@@ -55,8 +53,15 @@ module ForemanFogProxmox
       raise e
     end
 
-    def assign_vmid(vmid, node)
-      (vmid < 1) ? node.servers.next_id : vmid
+    def assign_vmid(vmid, node, log: true)
+      vmid = node.servers.next_id if vmid < 1
+
+      unless node.servers.id_valid?(vmid)
+        logger.warn("Requested VMID #{vmid} is occupied or out of range, requesting a new VMID") if log
+        vmid = node.servers.next_id
+      end
+
+      vmid
     end
 
     def compute_clone_attributes(args, container, type)

--- a/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
+
 # Copyright 2019 Tristan Robert
 
 # This file is part of ForemanFogProxmox.
@@ -182,10 +184,17 @@ module ForemanFogProxmox
       config_attributes.delete_if { |key, _value| ['disks', 'interfaces'].include?(key) }
     end
 
+    def assign_available_vmid(new_attr, node)
+      return if new_attr['vmid'].blank? || new_attr['node_id'].blank?
+
+      new_attr['vmid'] = assign_vmid(new_attr['vmid'].to_i, node, log: false)
+    end
+
     def new_typed_vm(new_attr, type)
       convert_config_attributes(new_attr) if new_attr.key?(:config_attributes)
       node_id = new_attr['node_id']
       node = node_id ? client.nodes.get(node_id) : default_node
+      assign_available_vmid(new_attr, node)
       new_attr_type = new_attr['type']
       new_attr_type ||= new_attr['config_attributes']['type'] if new_attr.key?('config_attributes')
       new_attr_type ||= type
@@ -201,3 +210,5 @@ module ForemanFogProxmox
     end
   end
 end
+
+# rubocop:enable Metrics/ModuleLength

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -31,15 +31,18 @@ module ForemanFogProxmox
     include ProxmoxVMHelper
 
     describe 'create_vm' do
-      it 'raises Foreman::Exception when vmid <= 100 and vmid > 0' do
-        args = { vmid: '100' }
+      it 'uses next vmid when requested vmid is occupied or out of range' do
+        args = { vmid: '100', type: 'qemu', node_id: 'proxmox', start_after_create: '0' }
         servers = mock('servers')
-        servers.stubs(:id_valid?).returns(false)
+        servers.expects(:id_valid?).with(100).returns(false)
+        servers.expects(:next_id).returns('101')
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
-        err = assert_raises Foreman::Exception do
-          cr.create_vm(args)
-        end
-        assert err.message.end_with?('invalid vmid=100')
+        cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
+        vm = mock('vm')
+        servers.expects(:create).with(args).returns(vm)
+        cr.create_vm(args)
+
+        assert_equal '101', args[:vmid]
       end
 
       it 'computes next vmid when vmid == 0 and creates server' do

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_test.rb
@@ -39,5 +39,30 @@ module ForemanFogProxmox
         assert cr.destroy_vm('abc')
       end
     end
+
+    describe 'assign_vmid' do
+      it 'uses next vmid when requested vmid is already occupied' do
+        cr = ForemanFogProxmox::Proxmox.new
+        servers = mock('servers')
+        node = mock('node')
+        node.stubs(:servers).returns(servers)
+        servers.expects(:id_valid?).with(100).returns(false)
+        servers.expects(:next_id).returns('101')
+
+        assert_equal '101', cr.assign_vmid(100, node)
+      end
+
+      it 'does not log when logging is disabled' do
+        cr = ForemanFogProxmox::Proxmox.new
+        servers = mock('servers')
+        node = mock('node')
+        node.stubs(:servers).returns(servers)
+        servers.expects(:id_valid?).with(100).returns(false)
+        servers.expects(:next_id).returns('101')
+        cr.logger.expects(:warn).never
+
+        assert_equal '101', cr.assign_vmid(100, node, log: false)
+      end
+    end
   end
 end

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_new_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_new_test.rb
@@ -111,5 +111,51 @@ module ForemanFogProxmox
         assert_equal vm, @cr.new_vm(attr)
       end
     end
+
+    describe 'assign_available_vmid' do
+      before do
+        @cr = FactoryBot.build_stubbed(:proxmox_cr)
+      end
+
+      it 'uses next vmid when requested vmid is already occupied' do
+        attr = { 'vmid' => '100', 'node_id' => 'proxmox' }.with_indifferent_access
+        servers = mock('servers')
+        node = mock('node')
+        node.stubs(:servers).returns(servers)
+        servers.expects(:id_valid?).with(100).returns(false)
+        servers.expects(:next_id).returns('101')
+        @cr.logger.expects(:warn).never
+
+        @cr.assign_available_vmid(attr, node)
+
+        assert_equal '101', attr['vmid']
+      end
+
+      it 'keeps requested vmid when it is available' do
+        attr = { 'vmid' => '100', 'node_id' => 'proxmox' }.with_indifferent_access
+        servers = mock('servers')
+        node = mock('node')
+        node.stubs(:servers).returns(servers)
+        servers.expects(:id_valid?).with(100).returns(true)
+        servers.expects(:next_id).never
+
+        @cr.assign_available_vmid(attr, node)
+
+        assert_equal 100, attr['vmid']
+      end
+
+      it 'does not assign vmid when requested vmid is blank' do
+        attr = { 'vmid' => '', 'node_id' => 'proxmox' }.with_indifferent_access
+        servers = mock('servers')
+        node = mock('node')
+        node.stubs(:servers).returns(servers)
+        servers.expects(:id_valid?).never
+        servers.expects(:next_id).never
+
+        @cr.assign_available_vmid(attr, node)
+
+        assert_equal '', attr['vmid']
+      end
+    end
   end
 end


### PR DESCRIPTION
- Updated the VMID assignment logic to automatically request the next available VMID when the requested VMID was unavailable (occupied/invalid)
- Removed the VMID validation exception during host creation and relied on automatic VMID reassignment instead.
- Prevented host creation from incorrectly entering the update path when the requested VMID is already occupied.
-  Added test coverage for VMID reassignment scenarios.