### PR TITLE
Add UEFI secure boot

### DIFF
--- a/app/helpers/proxmox_compute_selectors_helper.rb
+++ b/app/helpers/proxmox_compute_selectors_helper.rb
@@ -141,6 +141,7 @@ module ProxmoxComputeSelectorsHelper
 
   def proxmox_bios_map
     [OpenStruct.new(id: 'seabios', name: '(Default) Seabios'),
-     OpenStruct.new(id: 'ovmf', name: 'OVMF (UEFI)')]
+     OpenStruct.new(id: 'ovmf', name: 'OVMF (UEFI)'),
+     OpenStruct.new(id: 'uefi_secure_boot', name: 'OVMF (UEFI Secure Boot)')]
   end
 end

--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -132,8 +132,9 @@ module ProxmoxVMAttrsHelper
       ostemplate_file: vms.ostemplate_file,
       start_after_create: vms.start_after_create,
       templated: vms.templated,
+      is_secure_boot: vms.config.secure_boot?,
     }
-    vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname]
+    vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname, :is_secure_boot]
     extra_attrs = ActiveSupport::HashWithIndifferentAccess.new
     attributes.each do |key, value|
       camel_key = key.to_s.include?('_') ? snake_to_camel(key.to_s).to_sym : key

--- a/app/helpers/proxmox_vm_config_helper.rb
+++ b/app/helpers/proxmox_vm_config_helper.rb
@@ -60,7 +60,9 @@ module ProxmoxVMConfigHelper
       cpu_a += ForemanFogProxmox::HashCollection.stringify_keys(Fog::Proxmox::CpuHelper.flags).keys
       memory_a = ['memory', 'balloon', 'shares']
       cloud_init_a = ['ciuser', 'cipassword', 'searchdomain', 'nameserver']
+      firmware_a = ['is_secure_boot']
       keys.store(:cloud_init, cloud_init_a)
+      keys.store(:firmware, firmware_a)
     end
     keys.store(:main, main_a)
     keys.store(:cpu, cpu_a)
@@ -76,7 +78,7 @@ module ProxmoxVMConfigHelper
     config_a = []
     case type
     when 'qemu'
-      [:cpu, :memory, :general, :cloud_init].each { |key| config_a += config_typed_keys(type)[key] }
+      [:cpu, :memory, :general, :cloud_init, :firmware].each { |key| config_a += config_typed_keys(type)[key] }
     when 'lxc'
       [:main].each { |key| config_a += config_typed_keys(type)[key] }
     end

--- a/app/helpers/proxmox_vm_efidisk_helper.rb
+++ b/app/helpers/proxmox_vm_efidisk_helper.rb
@@ -23,6 +23,70 @@ require 'foreman_fog_proxmox/hash_collection'
 
 # Convert a foreman form server hash into a fog-proxmox server attributes hash
 module ProxmoxVMEfidiskHelper
+  def process_firmware_attributes(args, type)
+    return args unless type == 'qemu'
+    return args unless args
+
+    normalized_args = ActiveSupport::HashWithIndifferentAccess.new(args)
+    config = normalized_args[:config_attributes] || normalized_args
+    return args unless config.key?(:bios) || config.key?(:is_secure_boot)
+
+    args = normalized_args
+
+    bios = config[:bios]
+    secure_boot_value = config[:is_secure_boot]
+    secure_boot = bios == 'uefi_secure_boot' ||
+                  (bios == 'ovmf' && Foreman::Cast.to_bool(secure_boot_value))
+    config[:is_secure_boot] = secure_boot ? '1' : '0'
+
+    unless secure_boot
+      normalize_pre_enrolled_keys(args)
+      return args
+    end
+
+    config[:bios] = 'ovmf'
+    process_secure_boot_efidisk(args, config)
+  end
+
+  def normalize_pre_enrolled_keys(args)
+    efidisk = args[:efidisk_attributes]
+    return args if ForemanFogProxmox::Value.empty?(efidisk)
+
+    efidisk[:pre_enrolled_keys] = '0'
+    args
+  end
+
+  def process_secure_boot_efidisk(args, config)
+    efidisk = args[:efidisk_attributes]
+    unless ForemanFogProxmox::Value.empty?(efidisk)
+      args[:efidisk_attributes] = secure_boot_efidisk_attributes(
+        efidisk.merge('efitype' => '4m', 'pre_enrolled_keys' => '1')
+      )
+      return args
+    end
+
+    volumes = args[:volumes_attributes] || config[:volumes_attributes]
+    storage = volumes&.each_value&.filter_map { |volume| volume[:storage] }&.find(&:present?)
+    return args if ForemanFogProxmox::Value.empty?(storage)
+
+    args[:efidisk_attributes] = secure_boot_efidisk_attributes(storage: storage)
+    args
+  end
+
+  def efidisk_defaults(storage)
+    {
+      'id' => '0',
+      'volid' => "#{storage}:0",
+      'efitype' => '4m',
+      'pre_enrolled_keys' => '1',
+    }
+  end
+
+  def secure_boot_efidisk_attributes(attr = {})
+    attr = attr.to_h.stringify_keys
+    efidisk_defaults(attr['storage']).merge(attr)
+  end
+
   def parsed_typed_efidisk(args, type, parsed_vm)
     attrs = args['efidisk_attributes']
 

--- a/app/helpers/proxmox_vm_helper.rb
+++ b/app/helpers/proxmox_vm_helper.rb
@@ -19,6 +19,7 @@
 
 require 'fog/proxmox/helpers/disk_helper'
 require 'fog/proxmox/helpers/nic_helper'
+require 'foreman_fog_proxmox/hash_collection'
 require 'foreman_fog_proxmox/value'
 
 module ProxmoxVMHelper
@@ -34,8 +35,15 @@ module ProxmoxVMHelper
     collection
   end
 
+  def parse_vm_update_attributes(attributes, type)
+    ForemanFogProxmox::HashCollection.new_hash_reject_keys(
+      attributes, ['volumes_attributes']
+    ).merge(type: type)
+  end
+
   # Convert a foreman form server/container vm hash into a fog-proxmox server/container attributes hash
   def parse_typed_vm(args, type)
+    args = process_firmware_attributes(args, type)
     args = ActiveSupport::HashWithIndifferentAccess.new(args)
     return {} unless args
     return {} if args.empty?

--- a/app/models/concerns/fog_extensions/proxmox/server_config.rb
+++ b/app/models/concerns/fog_extensions/proxmox/server_config.rb
@@ -44,6 +44,15 @@ module FogExtensions
       def cloud_init?
         disks.any?(&:cloud_init?)
       end
+
+      def secure_boot?
+        attrs = attributes.with_indifferent_access
+        secure_boot = attrs[:is_secure_boot]
+        return Foreman::Cast.to_bool(secure_boot) ? '1' : '0' if attrs.key?(:is_secure_boot)
+
+        secure_boot = bios == 'ovmf' && Foreman::Cast.to_bool(efidisk&.pre_enrolled_keys)
+        Foreman::Cast.to_bool(secure_boot) ? '1' : '0'
+      end
     end
   end
 end

--- a/app/models/foreman_fog_proxmox/proxmox_efidisks.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_efidisks.rb
@@ -21,9 +21,17 @@ module ForemanFogProxmox
   module ProxmoxEfidisks
     include ProxmoxVMHelper
 
-    def delete_efidisk(vmobj)
-      logger.info("vm #{vmobj.identity} delete efidisk0")
-      vmobj.detach('efidisk0')
+    def delete_efidisk(vm_obj)
+      logger.info("vm #{vm_obj.identity} delete efidisk0")
+      vm_obj.detach('efidisk0')
+    end
+
+    def process_efidisk_removal(vm_obj, attributes)
+      return if vm_obj.config.efidisk.blank?
+      return if attributes['efidisk_attributes'].present?
+
+      logger.debug("Removing efidisk from VM #{vm_obj}")
+      delete_efidisk(vm_obj)
     end
   end
 end

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -110,10 +110,9 @@ module ForemanFogProxmox
       elsif vm.node_id != node_id
         vm.migrate(node_id)
       else
-        parsed_attr = parse_typed_vm(
-          ForemanFogProxmox::HashCollection.new_hash_reject_keys(new_attributes,
-            ['volumes_attributes']).merge(type: vm.type), vm.type
-        )
+        processed_attributes = process_firmware_attributes(new_attributes, vm.type)
+        update_attributes = parse_vm_update_attributes(processed_attributes, vm.type)
+        parsed_attr = parse_typed_vm(update_attributes, vm.type)
         config_attributes = compute_config_attributes(parsed_attr)
 
         volumes_attributes = new_attributes['volumes_attributes']
@@ -123,11 +122,7 @@ module ForemanFogProxmox
           save_volume(vm, volume_attributes)
         end
 
-        efidisk_attributes = new_attributes['efidisk_attributes']
-        if vm.config.efidisk.present? && efidisk_attributes.empty?
-          logger.debug("Removing efidisk from VM #{vm}")
-          delete_efidisk(vm)
-        end
+        process_efidisk_removal(vm, processed_attributes)
 
         vm.update(config_attributes[:config_attributes])
         poolid = new_attributes['pool'] if new_attributes.key?('pool')

--- a/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
@@ -190,6 +190,11 @@ module ForemanFogProxmox
       new_attr['vmid'] = assign_vmid(new_attr['vmid'].to_i, node, log: false)
     end
 
+    def add_secure_boot_attribute(vm_h, options, type)
+      secure_boot = options.dig('config_attributes', 'is_secure_boot')
+      vm_h[:is_secure_boot] = secure_boot if type == 'qemu' && secure_boot
+    end
+
     def new_typed_vm(new_attr, type)
       convert_config_attributes(new_attr) if new_attr.key?(:config_attributes)
       node_id = new_attr['node_id']
@@ -201,8 +206,10 @@ module ForemanFogProxmox
       logger.debug("new_typed_vm(#{type}): new_attr_type=#{new_attr_type}")
       logger.debug("new_typed_vm(#{type}): new_attr=#{new_attr}'")
       options = (!new_attr.key?('vmid') || ForemanFogProxmox::Value.empty?(new_attr['vmid'])) ? vm_typed_instance_defaults(type).merge(new_attr).merge(type: type) : new_attr
+      options = process_firmware_attributes(options, type)
       logger.debug("new_typed_vm(#{type}): options=#{options}")
       vm_h = parse_typed_vm(options, type).deep_symbolize_keys
+      add_secure_boot_attribute(vm_h, options, type)
       logger.debug("new_typed_vm(#{type}): vm_h=#{vm_h}")
       vm_h = vm_h.merge(vm_typed_instance_defaults(type)) if vm_h.empty?
       logger.debug(format(_('new_typed_vm(%<type>s) with vm_typed_instance_defaults: vm_h=%<vm_h>s'), type: type, vm_h: vm_h))

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_vm_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_vm_helper_test.rb
@@ -137,6 +137,72 @@ module ForemanFogProxmox
         } }
     end
 
+    describe '#parse_vm_update_attributes' do
+      it 'removes volume attributes and adds the VM type without parsing' do
+        attributes = parse_vm_update_attributes(host_server, 'qemu')
+
+        assert_not attributes.key?('volumes_attributes')
+        assert_equal 'qemu', attributes['type']
+        assert_equal host_server['config_attributes'], attributes['config_attributes']
+      end
+    end
+
+    describe '#parse_typed_vm firmware attributes' do
+      it 'maps secure boot to OVMF and adds a default EFI disk' do
+        host_server['config_attributes']['bios'] = 'uefi_secure_boot'
+
+        parsed_vm = parse_typed_vm(host_server, 'qemu')
+
+        assert_equal 'ovmf', parsed_vm['bios']
+        assert_equal 'local-lvm:0,efitype=4m,pre-enrolled-keys=1', parsed_vm['efidisk0']
+      end
+
+      it 'enables secure boot on an explicitly configured EFI disk' do
+        host_server['config_attributes']['bios'] = 'uefi_secure_boot'
+        host_server['efidisk_attributes'] = {
+          'id' => '0',
+          'volid' => 'fast-storage:0',
+          'efitype' => '2m',
+          'pre_enrolled_keys' => '0',
+        }
+
+        parsed_vm = parse_typed_vm(host_server, 'qemu')
+
+        assert_equal 'ovmf', parsed_vm['bios']
+        assert_equal 'fast-storage:0,efitype=4m,pre-enrolled-keys=1', parsed_vm['efidisk0']
+      end
+
+      it 'disables pre-enrolled keys on an existing OVMF EFI disk' do
+        host_server['config_attributes']['bios'] = 'ovmf'
+        host_server['efidisk_attributes'] = {
+          'id' => '0',
+          'volid' => 'fast-storage:0',
+          'efitype' => '4m',
+          'pre_enrolled_keys' => '1',
+        }
+
+        parsed_vm = parse_typed_vm(host_server, 'qemu')
+
+        assert_equal 'ovmf', parsed_vm['bios']
+        assert_equal 'fast-storage:0,efitype=4m,pre-enrolled-keys=0', parsed_vm['efidisk0']
+      end
+
+      it 'disables pre-enrolled keys for another BIOS' do
+        host_server['config_attributes']['bios'] = 'seabios'
+        host_server['efidisk_attributes'] = {
+          'id' => '0',
+          'volid' => 'fast-storage:0',
+          'efitype' => '4m',
+          'pre_enrolled_keys' => '1',
+        }
+
+        parsed_vm = parse_typed_vm(host_server, 'qemu')
+
+        assert_equal 'seabios', parsed_vm['bios']
+        assert_equal 'fast-storage:0,efitype=4m,pre-enrolled-keys=0', parsed_vm['efidisk0']
+      end
+    end
+
     describe 'object_to_config_hash' do
       setup { Fog.mock! }
       teardown { Fog.unmock! }

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_new_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_new_test.rb
@@ -110,6 +110,36 @@ module ForemanFogProxmox
         @cr.stubs(:new_typed_vm).with(attr, 'lxc').returns(vm)
         assert_equal vm, @cr.new_vm(attr)
       end
+
+      it 'processes secure boot firmware attributes before building profile VM' do
+        attr = {
+          'vmid' => '100',
+          'node_id' => 'proxmox',
+          'type' => 'qemu',
+          'config_attributes' => {
+            'bios' => 'uefi_secure_boot',
+          },
+          'volumes_attributes' => {
+            '0' => { 'storage' => 'local-lvm' },
+          },
+        }.with_indifferent_access
+        servers = mock('servers')
+        vm = mock('vm')
+        mock_node_servers(@cr, servers)
+        servers.stubs(:id_valid?).with(100).returns(true)
+        @cr.expects(:parse_typed_vm).with do |options, type|
+          assert_equal 'qemu', type
+          assert_equal 'ovmf', options['config_attributes']['bios']
+          assert_equal 'local-lvm:0', options['efidisk_attributes']['volid']
+        end.returns('bios' => 'ovmf', 'efidisk0' => 'local-lvm:0,efitype=4m,pre-enrolled-keys=1')
+        servers.expects(:new).with({
+          bios: 'ovmf',
+          efidisk0: 'local-lvm:0,efitype=4m,pre-enrolled-keys=1',
+          is_secure_boot: '1',
+        }).returns(vm)
+
+        assert_equal vm, @cr.new_typed_vm(attr, 'qemu')
+      end
     end
 
     describe 'assign_available_vmid' do

--- a/webpack/components/ProxmoxBiosContext.js
+++ b/webpack/components/ProxmoxBiosContext.js
@@ -3,11 +3,20 @@ import PropTypes from 'prop-types';
 
 const ProxmoxBiosContext = createContext(null);
 
-export function ProxmoxBiosProvider({ children, initialBios = null }) {
+export function ProxmoxBiosProvider({
+  children,
+  initialBios = null,
+  initialEfiDiskSelected = false,
+}) {
   const [bios, setBios] = useState(initialBios);
+  const [efiDiskSelected, setEfiDiskSelected] = useState(
+    initialEfiDiskSelected
+  );
 
-  // memoize so the provider value object changes only when bios changes
-  const value = useMemo(() => ({ bios, setBios }), [bios]);
+  const value = useMemo(
+    () => ({ bios, setBios, efiDiskSelected, setEfiDiskSelected }),
+    [bios, efiDiskSelected]
+  );
 
   return (
     <ProxmoxBiosContext.Provider value={value}>
@@ -26,8 +35,10 @@ export function useBios() {
 ProxmoxBiosProvider.propTypes = {
   children: PropTypes.object.isRequired,
   initialBios: PropTypes.string,
+  initialEfiDiskSelected: PropTypes.bool,
 };
 
 ProxmoxBiosProvider.defaultProps = {
   initialBios: null,
+  initialEfiDiskSelected: false,
 };

--- a/webpack/components/ProxmoxComputeSelectors.js
+++ b/webpack/components/ProxmoxComputeSelectors.js
@@ -179,6 +179,7 @@ const ProxmoxComputeSelectors = {
   proxmoxBiosMap: [
     { value: 'seabios', label: '(Default) Seabios' },
     { value: 'ovmf', label: 'OVMF (UEFI)' },
+    { value: 'uefi_secure_boot', label: 'OVMF (UEFI Secure Boot)' },
   ],
 };
 

--- a/webpack/components/ProxmoxServer/ProxmoxServerOptions.js
+++ b/webpack/components/ProxmoxServer/ProxmoxServerOptions.js
@@ -4,10 +4,11 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import InputField from '../common/FormInputs';
 import ProxmoxComputeSelectors from '../ProxmoxComputeSelectors';
 import { useBios } from '../ProxmoxBiosContext';
+import SecureBoot, { normalizeFirmwareOptions } from './components/SecureBoot';
 
 const ProxmoxServerOptions = ({ options }) => {
-  const [opts, setOpts] = useState(options);
-  const { setBios } = useBios();
+  const [opts, setOpts] = useState(normalizeFirmwareOptions(options));
+  const { efiDiskSelected, setBios } = useBios();
 
   const handleChange = e => {
     const { name, type, checked, value: targetValue } = e.target;
@@ -18,14 +19,21 @@ const ProxmoxServerOptions = ({ options }) => {
       value = targetValue;
     }
 
+    const updatedKey = Object.keys(opts).find(key => opts[key].name === name);
+    const updates = {
+      [updatedKey]: { ...opts[updatedKey], value },
+    };
     if (name === opts?.bios?.name) {
+      updates.isSecureBoot = {
+        ...opts.isSecureBoot,
+        value: value === 'uefi_secure_boot' ? '1' : '0',
+      };
       setBios(value);
     }
 
-    const updatedKey = Object.keys(opts).find(key => opts[key].name === name);
     setOpts(prevOpts => ({
       ...prevOpts,
-      [updatedKey]: { ...prevOpts[updatedKey], value },
+      ...updates,
     }));
   };
 
@@ -93,6 +101,11 @@ const ProxmoxServerOptions = ({ options }) => {
         options={ProxmoxComputeSelectors.proxmoxBiosMap}
         value={opts?.bios?.value}
         onChange={handleChange}
+      />
+      <SecureBoot
+        bios={opts?.bios}
+        isSecureBoot={opts?.isSecureBoot}
+        efiDiskSelected={efiDiskSelected}
       />
       <InputField
         name={opts?.ostype?.name}

--- a/webpack/components/ProxmoxServer/ProxmoxServerStorage.js
+++ b/webpack/components/ProxmoxServer/ProxmoxServerStorage.js
@@ -18,6 +18,7 @@ import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import HardDisk from './components/HardDisk';
 import CDRom from './components/CDRom';
 import EFIDisk from './components/EFIDisk';
+import { useBios } from '../ProxmoxBiosContext';
 
 const ProxmoxServerStorage = ({
   storage,
@@ -75,6 +76,7 @@ const ProxmoxServerStorage = ({
   const [cdRomIsNew, setCdRomIsNew] = useState(false);
   const [efiDisk, setEfiDisk] = useState(false);
   const [efiDiskData, setEfiDiskData] = useState(null);
+  const { setEfiDiskSelected } = useBios();
   const [nextDeviceNumbers, setNextDeviceNumbers] = useState({
     ide: 0,
     sata: 0,
@@ -381,13 +383,15 @@ const ProxmoxServerStorage = ({
       }
 
       setEfiDisk(true);
+      setEfiDiskSelected(true);
       setEfiDiskData(initEfiDisk);
     },
-    [efiDisk, paramScope]
+    [efiDisk, paramScope, setEfiDiskSelected]
   );
 
   const removeEfiDisk = () => {
     setEfiDisk(false);
+    setEfiDiskSelected(false);
   };
 
   if (isLoading) {

--- a/webpack/components/ProxmoxServer/components/EFIDisk.js
+++ b/webpack/components/ProxmoxServer/components/EFIDisk.js
@@ -19,7 +19,8 @@ const EFIDisk = ({ onRemove, data, storages, nodeId, vmId }) => {
   const [efidisk, setEfiDisk] = useState(data);
   const storagesMap = createStoragesMap(storages, null, nodeId);
   const { bios } = useBios();
-  const isBiosOvmf = bios === 'ovmf';
+  const isBiosOvmf = ['ovmf', 'uefi_secure_boot'].includes(bios);
+  const secureBootEnabled = bios === 'uefi_secure_boot';
 
   useEffect(() => {
     if (storagesMap?.length > 0 && !efidisk?.volid?.value) {
@@ -136,12 +137,20 @@ const EFIDisk = ({ onRemove, data, storages, nodeId, vmId }) => {
           onChange={handleChange}
         />
         <InputField
-          name={efidisk?.preEnrolledKeys?.name}
           label={__('Pre-Enrolled Keys')}
+          info={__(
+            'This checkbox is read-only and automatically checked when UEFI Secure Boot is selected'
+          )}
           type="checkbox"
-          value={efidisk?.preEnrolledKeys?.value}
-          checked={String(efidisk?.preEnrolledKeys?.value) === '1'}
+          value={secureBootEnabled ? '1' : '0'}
+          checked={secureBootEnabled}
           onChange={handleChange}
+          disabled
+        />
+        <input
+          name={efidisk?.preEnrolledKeys?.name}
+          type="hidden"
+          value={secureBootEnabled ? '1' : '0'}
         />
       </PageSection>
     </div>

--- a/webpack/components/ProxmoxServer/components/SecureBoot.js
+++ b/webpack/components/ProxmoxServer/components/SecureBoot.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const secureBootSelected = options =>
+  options?.bios?.value === 'uefi_secure_boot' ||
+  (options?.bios?.value === 'ovmf' &&
+    (String(options?.isSecureBoot?.value) === '1' ||
+      String(options?.efidisk?.preEnrolledKeys?.value) === '1'));
+
+export const normalizeFirmwareOptions = options => {
+  const isSecureBootSelected = secureBootSelected(options);
+
+  return {
+    ...options,
+    bios: {
+      ...options?.bios,
+      value: isSecureBootSelected ? 'uefi_secure_boot' : options?.bios?.value,
+    },
+    isSecureBoot: {
+      ...options?.isSecureBoot,
+      value: isSecureBootSelected ? '1' : '0',
+    },
+  };
+};
+
+const SecureBoot = ({ bios, isSecureBoot, efiDiskSelected }) => (
+  <>
+    {bios?.value === 'uefi_secure_boot' && !efiDiskSelected && (
+      <div className="form-group">
+        <div className="col-md-offset-2 col-md-6">
+          <FormHelperText>
+            <HelperText id="helper-secure-boot-efidisk">
+              <HelperTextItem variant="warning">
+                {__('Please make sure that an EFI disk is selected.')}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </div>
+      </div>
+    )}
+    {isSecureBoot?.name && (
+      <input
+        name={isSecureBoot.name}
+        type="hidden"
+        value={isSecureBoot?.value || '0'}
+      />
+    )}
+  </>
+);
+
+SecureBoot.propTypes = {
+  bios: PropTypes.object,
+  isSecureBoot: PropTypes.object,
+  efiDiskSelected: PropTypes.bool,
+};
+
+SecureBoot.defaultProps = {
+  bios: {},
+  isSecureBoot: {},
+  efiDiskSelected: false,
+};
+
+export default SecureBoot;

--- a/webpack/components/ProxmoxVmType.js
+++ b/webpack/components/ProxmoxVmType.js
@@ -299,7 +299,11 @@ const ProxmoxVmType = ({
   };
 
   return (
-    <ProxmoxBiosProvider>
+    <ProxmoxBiosProvider
+      initialEfiDiskSelected={
+        !!(vmAttrs?.efidisk && Object.keys(vmAttrs.efidisk).length > 0)
+      }
+    >
       <div>
         <InputField
           name={general?.type?.name}

--- a/webpack/components/__tests__/EFIDisk.test.js
+++ b/webpack/components/__tests__/EFIDisk.test.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ProxmoxBiosProvider } from '../ProxmoxBiosContext';
+import EFIDisk from '../ProxmoxServer/components/EFIDisk';
+
+const efiDiskData = {
+  id: { name: 'efidisk[id]', value: 0 },
+  volid: { name: 'efidisk[volid]', value: 'local:0' },
+  storage: { name: 'efidisk[storage]', value: 'local' },
+  format: { name: 'efidisk[format]', value: 'raw' },
+  preEnrolledKeys: { name: 'efidisk[pre_enrolled_keys]', value: '0' },
+};
+
+const renderEfiDisk = bios =>
+  render(
+    <ProxmoxBiosProvider initialBios={bios}>
+      <EFIDisk
+        onRemove={jest.fn()}
+        data={efiDiskData}
+        storages={[]}
+        nodeId="node-1"
+        vmId="100"
+      />
+    </ProxmoxBiosProvider>
+  );
+
+describe('EFIDisk', () => {
+  it('checks and disables pre-enrolled keys for UEFI Secure Boot', async () => {
+    const { container } = renderEfiDisk('uefi_secure_boot');
+
+    const checkbox = screen.getByRole('checkbox');
+    const submittedValue = container.querySelector(
+      'input[name="efidisk[pre_enrolled_keys]"]'
+    );
+
+    expect(checkbox).toBeDisabled();
+    expect(checkbox).toBeChecked();
+    expect(submittedValue).toHaveValue('1');
+    fireEvent.click(container.querySelector('.field-help'));
+    expect(
+      await screen.findByText(
+        'This checkbox is read-only and automatically checked when UEFI Secure Boot is selected'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('unchecks and disables pre-enrolled keys without UEFI Secure Boot', () => {
+    const { container } = renderEfiDisk('ovmf');
+
+    const checkbox = screen.getByRole('checkbox');
+    const submittedValue = container.querySelector(
+      'input[name="efidisk[pre_enrolled_keys]"]'
+    );
+
+    expect(checkbox).toBeDisabled();
+    expect(checkbox).not.toBeChecked();
+    expect(submittedValue).toHaveValue('0');
+  });
+});


### PR DESCRIPTION
- Add UEFI Secure Boot as a firmware option for Proxmox QEMU VMs.
- Automatically created a default EFI disk when Secure Boot was selected and no EFI disk existed.
- Translated UEFI Secure Boot to Proxmox's ovmf BIOS with pre-enrolled-keys=1.
- Extended VM parsing and serialization to support Secure Boot configuration.
- Reused the primary VM disk's storage when creating the default EFI disk.
- Added a warning message when UEFI Secure Boot was selected to inform users that an EFI disk with pre-enrolled keys is required. If none was provided, a default EFI disk was created automatically.
- Forced pre-enrolled-keys=0 for all BIOS modes except UEFI Secure Boot to ensure a valid firmware configuration.
- Added some tests for the new feature.