### PR TITLE
Fix prevent compute profile disks from overwriting image template disks

### DIFF
--- a/app/helpers/proxmox_compute_controllers_helper.rb
+++ b/app/helpers/proxmox_compute_controllers_helper.rb
@@ -18,15 +18,17 @@
 # along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>.
 
 module ProxmoxComputeControllersHelper
+  CONTROLLER_LIMITS = { 'ide' => 3, 'sata' => 5, 'scsi' => 30, 'virtio' => 15 }.freeze
+
   def proxmox_controllers_map
     proxmox_controllers_cloudinit_map << ForemanFogProxmox::OptionsSelect.new(name: 'VirtIO Block', id: 'virtio',
-      range: 15)
+      range: CONTROLLER_LIMITS['virtio'])
   end
 
   def proxmox_controllers_cloudinit_map
-    [ForemanFogProxmox::OptionsSelect.new(id: 'ide', name: 'IDE', range: 3),
-     ForemanFogProxmox::OptionsSelect.new(id: 'sata', name: 'SATA', range: 5),
-     ForemanFogProxmox::OptionsSelect.new(id: 'scsi', name: 'SCSI', range: 13)]
+    [ForemanFogProxmox::OptionsSelect.new(id: 'ide', name: 'IDE', range: CONTROLLER_LIMITS['ide']),
+     ForemanFogProxmox::OptionsSelect.new(id: 'sata', name: 'SATA', range: CONTROLLER_LIMITS['sata']),
+     ForemanFogProxmox::OptionsSelect.new(id: 'scsi', name: 'SCSI', range: CONTROLLER_LIMITS['scsi'])]
   end
 
   def proxmox_scsi_controllers_map

--- a/app/helpers/proxmox_vm_helper.rb
+++ b/app/helpers/proxmox_vm_helper.rb
@@ -25,6 +25,7 @@ require 'foreman_fog_proxmox/value'
 module ProxmoxVMHelper
   include ProxmoxVMInterfacesHelper
   include ProxmoxVMVolumesHelper
+  include ProxmoxVMImageTemplateHelper
   include ProxmoxVMConfigHelper
   include ProxmoxVMOsTemplateHelper
   include ProxmoxVMEfidiskHelper

--- a/app/helpers/proxmox_vm_image_template_helper.rb
+++ b/app/helpers/proxmox_vm_image_template_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# This file is part of ForemanFogProxmox.
+
+# ForemanFogProxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# ForemanFogProxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'fog/proxmox/helpers/disk_helper'
+
+module ProxmoxVMImageTemplateHelper
+  def validate_image_template_disk_slots!(image, args)
+    reserved_slots = image.config.disks.select(&:hard_disk?).map(&:id)
+    limits = ProxmoxComputeControllersHelper::CONTROLLER_LIMITS
+    volumes = args['volumes_attributes']&.values || []
+    used_slots = reserved_slots + volumes.filter_map { |volume| hard_disk_slot(volume) }
+
+    volumes.each do |volume_attributes|
+      volume = volume_attributes.with_indifferent_access
+      slot = hard_disk_slot(volume_attributes)
+      next unless slot
+
+      controller = volume[:controller]
+      if reserved_slots.include?(slot)
+        device = (0..limits.fetch(controller, -1)).find do |number|
+          !used_slots.include?("#{controller}#{number}")
+        end
+        unless device
+          raise ::Foreman::Exception,
+            format(_('No free disk device is available for the %<controller>s controller.'), controller: controller)
+        end
+
+        volume_attributes['device'] = device.to_s
+        volume_attributes['id'] = slot = "#{controller}#{device}"
+      end
+      used_slots << slot
+    end
+  end
+
+  def hard_disk_slot(attributes)
+    volume = attributes.with_indifferent_access
+    id = volume[:id]
+    id if volume_type?(volume, 'hard_disk') &&
+          Fog::Proxmox::DiskHelper.server_disk?(id)
+  end
+end

--- a/app/models/foreman_fog_proxmox/proxmox_images.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_images.rb
@@ -70,9 +70,8 @@ module ForemanFogProxmox
       find_vm_by_uuid(uuid)
     end
 
-    def clone_from_image(image_id, vmid)
-      logger.debug("create_vm(): clone #{image_id} in #{vmid}")
-      image = find_vm_by_uuid(image_id)
+    def clone_from_image(image, vmid)
+      logger.debug("create_vm(): clone #{image.identity} in #{vmid}")
       image.clone(vmid)
       find_vm_by_uuid(id.to_s + '_' + vmid.to_s)
     end

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -39,7 +39,9 @@ module ForemanFogProxmox
       image_id = args[:image_id]
       remove_volume_keys(args)
       if image_id
-        vm = clone_from_image(image_id, vmid)
+        image = find_vm_by_uuid(image_id)
+        validate_image_template_disk_slots!(image, args) if type == 'qemu'
+        vm = clone_from_image(image, vmid)
         vm.update(compute_clone_attributes(args, vm.container?, type))
         update_pool(vm, args[:pool]) if args[:pool]
       else

--- a/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
@@ -27,22 +27,20 @@ module ForemanFogProxmox
     describe 'clone_from_image' do
       before do
         @cr = FactoryBot.build_stubbed(:proxmox_cr)
-        @image_id = @cr.id.to_s + '_' + 100.to_s
         @vmid = 101
-        @image = mock('vm')
+        @image = mock('vm', identity: '100')
         @image.expects(:clone)
-        @cr.stubs(:find_vm_by_uuid).with(@image_id).returns(@image)
         @clone = mock('vm')
       end
       it 'clones server from image' do
         @clone.stubs(:container?).returns(false)
         @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
-        @cr.clone_from_image(@image_id, @vmid)
+        @cr.clone_from_image(@image, @vmid)
       end
       it 'clones container from image' do
         @clone.stubs(:container?).returns(true)
         @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
-        @cr.clone_from_image(@image_id, @vmid)
+        @cr.clone_from_image(@image, @vmid)
       end
     end
   end

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
@@ -299,7 +299,9 @@ module ForemanFogProxmox
         containers = mock('containers')
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
         vm = mock('vm')
-        cr.expects(:clone_from_image).with('999', 100).returns(vm)
+        image = mock('image')
+        cr.stubs(:find_vm_by_uuid).with('999').returns(image)
+        cr.expects(:clone_from_image).with(image, 100).returns(vm)
         vm.expects(:container?).returns(true)
         expected_args = { :vmid => "100", :type => "lxc" }
         cr.stubs(:parse_typed_vm).with(args, 'lxc').returns(expected_args)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -103,7 +103,9 @@ module ForemanFogProxmox
         servers.stubs(:id_valid?).returns(true)
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
         vm = mock('vm')
-        cr.expects(:clone_from_image).with('999', 100).returns(vm)
+        image = mock('image', config: mock('config', disks: []))
+        cr.stubs(:find_vm_by_uuid).with('999').returns(image)
+        cr.expects(:clone_from_image).with(image, 100).returns(vm)
         vm.expects(:container?).returns(false)
         expected_args = { :vmid => "100", :type => "qemu", :name => "name" }
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(expected_args)
@@ -140,6 +142,69 @@ module ForemanFogProxmox
         end
 
         assert err.message.end_with?('Could not find generated cloud-init ISO name_cloudinit.iso on any ISO storage for node proxmox')
+      end
+    end
+
+    describe 'validate_image_template_disk_slots!' do
+      it 'moves a disk that conflicts with an image template disk to the next free slot' do
+        cr = ForemanFogProxmox::Proxmox.new
+        disk = mock('disk', hard_disk?: true, id: 'scsi0')
+        image = mock('image', config: mock('config', disks: [disk]))
+        args = {
+          'volumes_attributes' => {
+            '0' => { 'storage_type' => 'hard_disk', 'controller' => 'scsi', 'device' => '0', 'id' => 'scsi0' },
+          },
+        }
+        cr.validate_image_template_disk_slots!(image, args)
+
+        assert_equal '1', args['volumes_attributes']['0']['device']
+        assert_equal 'scsi1', args['volumes_attributes']['0']['id']
+      end
+
+      it 'uses a free slot before the conflicting slot' do
+        cr = ForemanFogProxmox::Proxmox.new
+        disk = mock('disk', hard_disk?: true, id: 'scsi1')
+        image = mock('image', config: mock('config', disks: [disk]))
+        args = {
+          'volumes_attributes' => {
+            '0' => { 'storage_type' => 'hard_disk', 'controller' => 'scsi', 'device' => '1', 'id' => 'scsi1' },
+          },
+        }
+        cr.validate_image_template_disk_slots!(image, args)
+
+        assert_equal '0', args['volumes_attributes']['0']['device']
+        assert_equal 'scsi0', args['volumes_attributes']['0']['id']
+      end
+
+      it 'leaves a disk unchanged when its slot does not conflict with an image template disk' do
+        cr = ForemanFogProxmox::Proxmox.new
+        disk = mock('disk', hard_disk?: true, id: 'scsi0')
+        image = mock('image', config: mock('config', disks: [disk]))
+        args = {
+          'volumes_attributes' => {
+            '0' => { 'storage_type' => 'hard_disk', 'controller' => 'scsi', 'device' => '1', 'id' => 'scsi1' },
+          },
+        }
+        original_args = args.deep_dup
+        cr.validate_image_template_disk_slots!(image, args)
+
+        assert_equal original_args, args
+      end
+
+      it 'raises when no free disk slot is available for the controller' do
+        cr = ForemanFogProxmox::Proxmox.new
+        disks = (0..3).map { |device| mock("disk#{device}", hard_disk?: true, id: "ide#{device}") }
+        image = mock('image', config: mock('config', disks: disks))
+        args = {
+          'volumes_attributes' => {
+            '0' => { 'storage_type' => 'hard_disk', 'controller' => 'ide', 'device' => '3', 'id' => 'ide3' },
+          },
+        }
+        error = assert_raises Foreman::Exception do
+          cr.validate_image_template_disk_slots!(image, args)
+        end
+
+        assert_equal 'No free disk device is available for the ide controller.', error.bare_message
       end
     end
   end


### PR DESCRIPTION
- Prevented compute profile disks from overwriting image template disks during image-based provisioning.
- Automatically assigned the next available disk slot when a conflict was detected.
- Raised an error when no free disk slot was available.
- Added unit tests covering disk slot conflict resolution and the no-free-slot scenario.