### PR TITLE
Fixes #502 - Serialize cached OpenStructs via to_h in metadata endpoint

### DIFF
--- a/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
+++ b/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
@@ -121,7 +121,7 @@ module ForemanFogProxmox
 
     def extract_storages(compute_resource)
       Array(compute_resource.storages).map do |s|
-        h = s.respond_to?(:as_json) ? s.as_json : s
+        h = s.respond_to?(:to_h) ? s.to_h : s
         {
           storage: (h[:storage] || h['storage']),
           node_id: (h[:node_id] || h['node_id']),
@@ -135,7 +135,7 @@ module ForemanFogProxmox
 
     def extract_bridges(compute_resource)
       Array(compute_resource.bridges).map do |b|
-        h = b.respond_to?(:as_json) ? b.as_json : b
+        h = b.respond_to?(:to_h) ? b.to_h : b
         {
           node_id: (h[:node_id] || h['node_id']),
           iface: (h[:iface] || h['iface']),

--- a/test/functional/compute_resources_controller_test.rb
+++ b/test/functional/compute_resources_controller_test.rb
@@ -106,5 +106,41 @@ module ForemanFogProxmox
       assert_instance_of Array, json_response['storages']
       assert_instance_of Array, json_response['bridges']
     end
+    test 'should serialize OpenStruct-wrapped storages in metadata' do
+      # Simulates structs_from_cache output which wraps items in OpenStruct.
+      # OpenStruct#as_json returns { "table" => {...} } on Ruby 3.x, so using
+      # as_json here would produce null fields — the bug fixed by this PR.
+      cached_storage = OpenStruct.new(
+        storage: 'local-lvm',
+        node_id: 'proxmox',
+        content: 'images',
+        avail: 100_000_000_000,
+        used: 40_000_000_000,
+        total: 140_000_000_000
+      )
+      @compute_resource.stubs(:storages).returns([cached_storage])
+
+      get :metadata, params: { :compute_resource_id => @compute_resource.id }, session: set_session_user
+      assert_response :success
+      json_response = JSON.parse(@response.body)
+      storage = json_response['storages'].first
+      assert_equal 'local-lvm', storage['storage']
+      assert_equal 'proxmox', storage['node_id']
+      assert_equal 'images', storage['content']
+      assert_equal 100_000_000_000, storage['avail']
+      assert_equal 40_000_000_000, storage['used']
+      assert_equal 140_000_000_000, storage['total']
+    end
+    test 'should serialize OpenStruct-wrapped bridges in metadata' do
+      cached_bridge = OpenStruct.new(node_id: 'proxmox', iface: 'vmbr0')
+      @compute_resource.stubs(:bridges).returns([cached_bridge])
+
+      get :metadata, params: { :compute_resource_id => @compute_resource.id }, session: set_session_user
+      assert_response :success
+      json_response = JSON.parse(@response.body)
+      bridge = json_response['bridges'].first
+      assert_equal 'proxmox', bridge['node_id']
+      assert_equal 'vmbr0', bridge['iface']
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #502

`ComputeResourcesController#extract_storages` and `#extract_bridges` (introduced by the caching commit 404173f) call `s.as_json` on items returned by `ProxmoxVMQueries#storages` / `#bridges`. Those items are wrapped in `OpenStruct.new(...)` by `structs_from_cache`.

On Ruby 3.x, `OpenStruct#as_json` returns `{"table" => {...}}` (the attributes nested under the internal `@table` ivar name) rather than a flat hash. As a result the subsequent `h[:storage] || h['storage']` lookups return `nil`, and the metadata endpoint responds with:

```json
{
  "storages": [
    { "storage": null, "node_id": null, "content": null, "avail": null, "used": null, "total": null }
  ],
  "bridges": [
    { "node_id": null, "iface": null }
  ]
}
```

The React UI then feeds `undefined` into `humanSize()`, producing `(free: NaN undefined, used: NaN undefined, total: NaN undefined)` in every storage dropdown.

## Fix

Replace `.as_json` with `.to_h` on the OpenStruct items. `.to_h` returns the flat hash directly, so the existing `h[:key]` lookups then find the expected fields.

## Reproduction

Before:

```bash
curl -sk -u admin:pass -H 'Accept: application/json' \
  https://foreman/foreman_fog_proxmox/metadata/<cr_id> | jq '.storages[0]'
# → { "storage": null, "avail": null, "used": null, "total": null }
```

After (with Foreman restarted and `tmp/cache/bootsnap*` cleared):

```bash
# → { "storage": "cephDATA", "avail": 1425686265856, "used": 1104826798592, "total": 2530513064448 }
```

Verified locally on Foreman 3.19.1 (Debian 12) with `ruby-foreman-fog-proxmox 0.24.0-1~fm3.19`. Dropdown now displays actual sizes for Ceph RBD, LVM-thin and ZFS backends.

## Testing gap

Existing unit tests cover `ProxmoxVMQueries#storages` on the model level but do not exercise the JSON serialization done in the controller. Happy to add a small functional test on `#metadata` covering the OpenStruct-wrap path if reviewers want it.

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638): the debugging session, the diagnosis text and the commit wording were done with Claude (Anthropic) as an assistant. The reproduction and verification steps ran on my own production Foreman instance; the diagnosis and the two-line change were reviewed and validated by me before submitting. Also noted as an `Assisted-By` trailer in the commit.
