### PR TITLE
Fix exclude CD-ROM from network provisioning boot order

### DIFF
--- a/app/helpers/proxmox_vm_cloudinit_helper.rb
+++ b/app/helpers/proxmox_vm_cloudinit_helper.rb
@@ -106,7 +106,6 @@ module ProxmoxVMCloudinitHelper
     configs = filenames.zip(config_data).to_h
 
     iso = create_cloudinit_iso(args[:name], configs, ssh)
-    args[:config_attributes]&.merge!(update_boot_order(args[:image_id]))
     args.merge!(attach_cloudinit_iso(args[:node_id], iso))
   end
 
@@ -124,13 +123,6 @@ module ProxmoxVMCloudinitHelper
 
   def default_iso_path
     "/var/lib/vz/template/iso"
-  end
-
-  def update_boot_order(image_id)
-    vm = find_vm_by_uuid(image_id)
-    return if vm.disks.nil?
-    disks = vm.disks.map { |disk| disk.split(":")[0] }.join(";")
-    { boot: "order=" + disks }
   end
 
   def vm_ssh

--- a/app/helpers/proxmox_vm_helper.rb
+++ b/app/helpers/proxmox_vm_helper.rb
@@ -42,6 +42,19 @@ module ProxmoxVMHelper
     ).merge(type: type)
   end
 
+  def update_boot_order(instance, exclude_cdrom: false, include_network: false)
+    return {} unless instance
+
+    disks = Array(instance.disks).map { |disk| disk.split(":")[0] }
+    disks.delete("ide2") if exclude_cdrom
+    network_interfaces = include_network ? Array(instance.interfaces).map(&:id) : []
+    boot_devices = network_interfaces + disks
+
+    return {} if boot_devices.empty?
+
+    { boot: "order=" + boot_devices.join(";") }
+  end
+
   # Convert a foreman form server/container vm hash into a fog-proxmox server/container attributes hash
   def parse_typed_vm(args, type)
     args = process_firmware_attributes(args, type)

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -42,11 +42,15 @@ module ForemanFogProxmox
         image = find_vm_by_uuid(image_id)
         validate_image_template_disk_slots!(image, args) if type == 'qemu'
         vm = clone_from_image(image, vmid)
-        vm.update(compute_clone_attributes(args, vm.container?, type))
+        vm.update(compute_clone_attributes(args, vm.container?, type, image: image))
         update_pool(vm, args[:pool]) if args[:pool]
       else
         logger.warn("create vm: args=#{args}")
         vm = node.send(vm_collection(type)).create(parse_typed_vm(args, type))
+        if type == 'qemu' && vm
+          boot_order = update_boot_order(vm, exclude_cdrom: true, include_network: true)
+          vm.update(boot_order) if boot_order
+        end
       end
       start_on_boot(vm, args)
     rescue StandardError => e
@@ -66,8 +70,9 @@ module ForemanFogProxmox
       vmid
     end
 
-    def compute_clone_attributes(args, container, type)
+    def compute_clone_attributes(args, container, type, image: nil)
       args = parse_cloudinit_config(args) if args[:user_data]
+      args[:config_attributes].merge!(update_boot_order(image)) if image && args[:config_attributes]
       parsed_args = parse_typed_vm(args, type)
       if container
         options = { :hostname => args[:name] }

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_vm_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_vm_helper_test.rb
@@ -203,6 +203,40 @@ module ForemanFogProxmox
       end
     end
 
+    describe 'update_boot_order' do
+      let(:vm) do
+        vm = mock('vm')
+        vm.stubs(:disks).returns(['scsi0: local-lvm:vm-100-disk-0', 'ide2: none,media=cdrom', 'virtio1: local-lvm:vm-100-disk-1'])
+        net0 = mock('net0')
+        net1 = mock('net1')
+        net0.stubs(:id).returns('net0')
+        net1.stubs(:id).returns('net1')
+        vm.stubs(:interfaces).returns([net0, net1])
+        vm
+      end
+
+      it 'generates the image provisioning boot order from all disks' do
+        assert_equal({ boot: 'order=scsi0;ide2;virtio1' }, update_boot_order(vm))
+      end
+
+      it 'includes network interfaces and excludes the default CD-ROM for network provisioning' do
+        expected_boot_order = { boot: 'order=net0;net1;scsi0;virtio1' }
+
+        assert_equal expected_boot_order, update_boot_order(vm, exclude_cdrom: true, include_network: true)
+      end
+
+      it 'returns an empty hash when the VM is missing' do
+        assert_empty(update_boot_order(nil))
+      end
+
+      it 'returns an empty hash when the VM has no disks' do
+        vm = mock('vm')
+        vm.stubs(:disks).returns(nil)
+
+        assert_empty(update_boot_order(vm))
+      end
+    end
+
     describe 'object_to_config_hash' do
       setup { Fog.mock! }
       teardown { Fog.unmock! }

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -38,6 +38,7 @@ module ForemanFogProxmox
         servers.expects(:next_id).returns('101')
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
+        cr.stubs(:update_boot_order).returns(nil)
         vm = mock('vm')
         servers.expects(:create).with(args).returns(vm)
         cr.create_vm(args)
@@ -70,12 +71,27 @@ module ForemanFogProxmox
         cr.create_vm(args)
       end
 
+      it 'updates the boot order after creating a network-provisioned server' do
+        args = { vmid: '100', type: 'qemu', node_id: 'proxmox', start_after_create: '0' }
+        servers = mock('servers')
+        servers.stubs(:id_valid?).returns(true)
+        vm = mock('vm')
+        servers.expects(:create).with(args).returns(vm)
+        cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
+        cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
+        cr.expects(:update_boot_order).with(vm, exclude_cdrom: true, include_network: true).returns(boot: 'order=net0;scsi0;virtio1')
+        vm.expects(:update).with({ boot: 'order=net0;scsi0;virtio1' })
+
+        cr.create_vm(args)
+      end
+
       it 'creates server with bootstart' do
         args = { vmid: '100', type: 'qemu', node_id: 'proxmox', start_after_create: '1' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
+        cr.stubs(:update_boot_order).returns(nil)
         vm = mock('vm')
         servers.stubs(:create).with(args).returns(vm)
         cr.stubs(:find_vm_by_uuid).with((args[:vmid]).to_s).returns(vm)
@@ -89,6 +105,7 @@ module ForemanFogProxmox
         servers.stubs(:id_valid?).returns(true)
         cr = mock_node_servers(ForemanFogProxmox::Proxmox.new, servers)
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(args)
+        cr.stubs(:update_boot_order).returns(nil)
         vm = mock('vm')
         servers.stubs(:create).with(args).returns(vm)
         cr.stubs(:find_vm_by_uuid).with((args[:vmid]).to_s).returns(vm)
@@ -110,6 +127,26 @@ module ForemanFogProxmox
         expected_args = { :vmid => "100", :type => "qemu", :name => "name" }
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(expected_args)
         vm.expects(:update).with(expected_args)
+        cr.create_vm(args)
+      end
+
+      it 'updates the boot order when cloning without user data' do
+        args = { vmid: '100', type: 'qemu', image_id: '999', name: 'name', config_attributes: { onboot: '0' } }
+        servers = mock('servers')
+        containers = mock('containers')
+        servers.stubs(:id_valid?).returns(true)
+        cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
+        image = mock('image', config: mock('config', disks: []))
+        vm = mock('vm')
+        cr.expects(:clone_from_image).with(image, 100).returns(vm)
+        vm.expects(:container?).returns(false)
+        cr.expects(:parse_cloudinit_config).never
+        cr.expects(:find_vm_by_uuid).with('999').once.returns(image)
+        cr.expects(:update_boot_order).with(image).returns(boot: 'order=scsi0;virtio1')
+        expected_args = { vmid: '100', type: 'qemu', name: 'name', config_attributes: { onboot: '0', boot: 'order=scsi0;virtio1' } }
+        cr.expects(:parse_typed_vm).with(args, 'qemu').returns(expected_args)
+        vm.expects(:update).with(expected_args)
+
         cr.create_vm(args)
       end
 


### PR DESCRIPTION
- Excluded the default CD-ROM (ide2) from the boot order during network provisioning.
- Preserved the existing boot order behavior for image provisioning.
- Added unit tests covering both image and network provisioning boot order generation.