### PR TITLE
Fixes #493 - Return storages and bridges for all nodes in metadata endpoint

### DIFF
--- a/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
+++ b/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
@@ -95,20 +95,21 @@ module ForemanFogProxmox
     # GET foreman_fog_proxmox/metadata/:compute_resource_id
     def metadata
       cr = ComputeResource.find(params[:compute_resource_id])
+      nodes = Array(cr.nodes)
 
       render json: {
-        nodes: extract_nodes(cr),
+        nodes: extract_nodes(nodes),
         pools: extract_pools(cr),
-        storages: extract_storages(cr),
-        bridges: extract_bridges(cr),
+        storages: extract_storages(cr, nodes),
+        bridges: extract_bridges(cr, nodes),
         images: extract_images(cr),
       }
     end
 
     private
 
-    def extract_nodes(compute_resource)
-      Array(compute_resource.nodes).map { |n| { node: n.node } }
+    def extract_nodes(nodes)
+      nodes.map { |node| { node: node.node } }
     end
 
     def extract_pools(compute_resource)
@@ -118,27 +119,29 @@ module ForemanFogProxmox
       end
     end
 
-    def extract_storages(compute_resource)
-      Array(compute_resource.storages).map do |s|
-        h = s.respond_to?(:as_json) ? s.as_json : s
-        {
-          storage: (h[:storage] || h['storage']),
-          node_id: (h[:node_id] || h['node_id']),
-          content: (h[:content] || h['content']),
-          avail: (h[:avail] || h['avail']),
-          used: (h[:used] || h['used']),
-          total: (h[:total] || h['total']),
-        }
+    def extract_storages(compute_resource, nodes)
+      nodes.flat_map do |node|
+        Array(compute_resource.storages(node.node)).map do |storage|
+          {
+            storage: storage.storage,
+            node_id: node.node,
+            content: storage.content,
+            avail: storage.avail,
+            used: storage.used,
+            total: storage.total,
+          }
+        end
       end
     end
 
-    def extract_bridges(compute_resource)
-      Array(compute_resource.bridges).map do |b|
-        h = b.respond_to?(:as_json) ? b.as_json : b
-        {
-          node_id: (h[:node_id] || h['node_id']),
-          iface: (h[:iface] || h['iface']),
-        }
+    def extract_bridges(compute_resource, nodes)
+      nodes.flat_map do |node|
+        Array(compute_resource.bridges(node.node)).map do |bridge|
+          {
+            node_id: node.node,
+            iface: bridge.iface,
+          }
+        end
       end
     end
 

--- a/test/functional/compute_resources_controller_test.rb
+++ b/test/functional/compute_resources_controller_test.rb
@@ -94,5 +94,50 @@ module ForemanFogProxmox
       assert_instance_of Array, json_response['storages']
       assert_instance_of Array, json_response['bridges']
     end
+    test 'should return storages from all nodes in metadata' do
+      nodes = [OpenStruct.new(node: 'proxmox1'), OpenStruct.new(node: 'proxmox2')]
+      ceph1 = OpenStruct.new(storage: 'ceph', content: 'images', avail: 5_000, used: 1_000, total: 6_000)
+      ceph2 = OpenStruct.new(storage: 'ceph', content: 'images', avail: 5_000, used: 1_000, total: 6_000)
+      @compute_resource.stubs(:nodes).returns(nodes)
+      @compute_resource.stubs(:storages).with('proxmox1').returns([ceph1])
+      @compute_resource.stubs(:storages).with('proxmox2').returns([ceph2])
+      @compute_resource.stubs(:bridges).with('proxmox1').returns([])
+      @compute_resource.stubs(:bridges).with('proxmox2').returns([])
+
+      get :metadata, params: { :compute_resource_id => @compute_resource.id }, session: set_session_user
+      assert_response :success
+
+      storages = JSON.parse(@response.body)['storages']
+      storage_nodes = storages.map { |storage| [storage['storage'], storage['node_id']] }
+      assert_equal [['ceph', 'proxmox1'], ['ceph', 'proxmox2']], storage_nodes
+    end
+    test 'should return bridges from all nodes in metadata' do
+      nodes = [OpenStruct.new(node: 'proxmox1'), OpenStruct.new(node: 'proxmox2')]
+      vmbr1 = OpenStruct.new(iface: 'vmbr0')
+      vmbr2 = OpenStruct.new(iface: 'vmbr0')
+      @compute_resource.stubs(:nodes).returns(nodes)
+      @compute_resource.stubs(:storages).with('proxmox1').returns([])
+      @compute_resource.stubs(:storages).with('proxmox2').returns([])
+      @compute_resource.stubs(:bridges).with('proxmox1').returns([vmbr1])
+      @compute_resource.stubs(:bridges).with('proxmox2').returns([vmbr2])
+
+      get :metadata, params: { :compute_resource_id => @compute_resource.id }, session: set_session_user
+      assert_response :success
+
+      bridges = JSON.parse(@response.body)['bridges']
+      bridge_nodes = bridges.map { |bridge| [bridge['iface'], bridge['node_id']] }
+      assert_equal [['vmbr0', 'proxmox1'], ['vmbr0', 'proxmox2']], bridge_nodes
+    end
+    test 'should fetch nodes once while building metadata' do
+      nodes = [OpenStruct.new(node: 'proxmox1'), OpenStruct.new(node: 'proxmox2')]
+      @compute_resource.expects(:nodes).once.returns(nodes)
+      @compute_resource.stubs(:storages).with('proxmox1').returns([])
+      @compute_resource.stubs(:storages).with('proxmox2').returns([])
+      @compute_resource.stubs(:bridges).with('proxmox1').returns([])
+      @compute_resource.stubs(:bridges).with('proxmox2').returns([])
+
+      get :metadata, params: { :compute_resource_id => @compute_resource.id }, session: set_session_user
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #493.

Fixes #474 — the same issue leaves the **Bridge** dropdown empty on compute profiles. The React form filters metadata by `node_id`, but the endpoint only returned resources from the default node.

## Cause

`ComputeResourcesController#extract_storages` and `#extract_bridges` called `compute_resource.storages` and `compute_resource.bridges` without a node ID. `ProxmoxVMQueries` therefore used `default_node_id` and omitted resources belonging to the remaining cluster nodes.

When another node was selected, the React form filtered the response by its `node_id` and found no matching storage or bridge entries.

## Changes

- Fetch the cluster node list once.
- Query storages and bridges for every node.
- Preserve one metadata row per node, including shared resources, so client-side filtering by `node_id` remains correct.
- Set `node_id` from the node being queried instead of relying on the value returned by Fog.
- Return empty arrays when nodes, storages, or bridges are unavailable.

## Merge dependency

This change queries storages and bridges on every cluster node. It therefore depends on #508, which handles witness or arbiter nodes without access to shared storage.

Please merge #508 before #505. Without #508, querying storage on such a node can raise and cause the metadata endpoint to return HTTP 500.

## Tests

- Metadata includes storages from every node.
- Metadata includes bridges from every node.
- Shared storages and bridges remain available for each node.
- Metadata assigns resources to the node that was queried.
- The node list is fetched only once.

## Reproduction

1. Create a VM host in Foreman with a multi-node Proxmox compute resource.
2. In the Virtual Machine tab, select any node other than the first.
3. Open **Storage** and add an EFI or hard disk, or open **Network**.
4. The storage or bridge dropdown is empty.

After this patch, the dropdowns contain resources belonging to the selected node.

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the diagnosis, code changes, tests, and PR wording were prepared with Claude (Anthropic) as an assistant. Reproduction and verification were performed on a production Foreman instance, and the resulting changes were reviewed before pushing. The commit also includes an `Assisted-By` trailer.
