### PR TITLE
Fix cloud-init ISO upload

### DIFF
--- a/app/helpers/proxmox_vm_cloudinit_helper.rb
+++ b/app/helpers/proxmox_vm_cloudinit_helper.rb
@@ -112,8 +112,10 @@ module ProxmoxVMCloudinitHelper
 
   def attach_cloudinit_iso(node, iso)
     volume = nil
-    storages(node, 'iso').each do |storage|
-      volume = storage.volumes.detect { |v| v.volid.include? File.basename(iso) }
+    node_obj = client.nodes.get(node)
+    node_obj&.storages&.list_by_content_type('iso')&.each do |storage|
+      volumes = storage.volumes
+      volume = Array(volumes).detect { |v| v.volid.include? File.basename(iso) }
       break if volume
     end
 

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -120,7 +120,15 @@ module ForemanFogProxmox
         first_storage.stubs(:volumes).returns([])
         volume.stubs(:volid).returns('local:iso/name_cloudinit.iso')
         second_storage.stubs(:volumes).returns([volume])
-        cr.stubs(:storages).with('proxmox', 'iso').returns([first_storage, second_storage])
+        storages = mock('storages')
+        storages.stubs(:list_by_content_type).with('iso').returns([first_storage, second_storage])
+        node = mock('node')
+        node.stubs(:storages).returns(storages)
+        nodes = mock('nodes')
+        nodes.stubs(:get).with('proxmox').returns(node)
+        client = mock('client')
+        client.stubs(:nodes).returns(nodes)
+        cr.stubs(:client).returns(client)
 
         assert_equal({ ide2: 'local:iso/name_cloudinit.iso,media=cdrom' },
           cr.attach_cloudinit_iso('proxmox', '/var/lib/vz/template/iso/name_cloudinit.iso'))
@@ -133,7 +141,15 @@ module ForemanFogProxmox
 
         other_volume.stubs(:volid).returns('local:iso/other.iso')
         storage.stubs(:volumes).returns([other_volume])
-        cr.stubs(:storages).with('proxmox', 'iso').returns([storage])
+        storages = mock('storages')
+        storages.stubs(:list_by_content_type).with('iso').returns([storage])
+        node = mock('node')
+        node.stubs(:storages).returns(storages)
+        nodes = mock('nodes')
+        nodes.stubs(:get).with('proxmox').returns(node)
+        client = mock('client')
+        client.stubs(:nodes).returns(nodes)
+        cr.stubs(:client).returns(client)
 
         err = assert_raises Foreman::Exception do
           cr.attach_cloudinit_iso('proxmox', '/var/lib/vz/template/iso/name_cloudinit.iso')

--- a/webpack/components/ProxmoxStoragesUtils.js
+++ b/webpack/components/ProxmoxStoragesUtils.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
 const humanSize = size => {

--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -8,4 +8,5 @@ global.console.error = (error, stack) => {
 };
 
 // Increase jest timeout as some tests using multiple http mocks can time out on CI systems.
+/* eslint-disable-next-line no-magic-numbers */
 jest.setTimeout(10000);


### PR DESCRIPTION
- Fixed storages(node, 'iso') since now returns serialized/cached data instead of Fog objects, so methods like storage.volumes are no longer available.