### PR TITLE
Fix ESLint no-magic-numbers errors under Foreman develop

### DIFF
--- a/webpack/components/ProxmoxStoragesUtils.js
+++ b/webpack/components/ProxmoxStoragesUtils.js
@@ -1,8 +1,12 @@
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
+// Unit selection uses a 1024 step (binary); the value is scaled by 1000 (decimal).
+const BYTE_UNIT_STEP = 1024;
+const BYTE_UNIT_DIVISOR = 1000;
+
 const humanSize = size => {
-  const i = Math.floor(Math.log(size) / Math.log(1024));
-  return `${(size / 1000 ** i).toFixed(2) * 1} ${
+  const i = Math.floor(Math.log(size) / Math.log(BYTE_UNIT_STEP));
+  return `${(size / BYTE_UNIT_DIVISOR ** i).toFixed(2) * 1} ${
     ['B', 'kB', 'MB', 'GB', 'TB'][i]
   }`;
 };

--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -8,4 +8,5 @@ global.console.error = (error, stack) => {
 };
 
 // Increase jest timeout as some tests using multiple http mocks can time out on CI systems.
-jest.setTimeout(10000);
+const JEST_TIMEOUT_MS = 10000;
+jest.setTimeout(JEST_TIMEOUT_MS);


### PR DESCRIPTION
### Problem

The `JavaScript` checks are currently red on every open PR in this repository. The `JavaScript / Test suite` status is only an aggregate — the real failure is in the ESLint step (`npm run lint:plugins foreman_fog_proxmox`):

```
webpack/components/ProxmoxStoragesUtils.js
  4:50   error  No magic number: 1024   no-magic-numbers
  5:21   error  No magic number: 1000   no-magic-numbers
webpack/global_test_setup.js
  11:17  error  No magic number: 10000  no-magic-numbers
```

### Why it fails now

These lines have been on `master` for a long time (`ProxmoxStoragesUtils.js` since #439, `global_test_setup.js` since the initial JS test setup) and passed CI when they were merged. The JS job builds against Foreman `develop`, whose shared ESLint config now enforces `no-magic-numbers` (`enforceConst: true`), so code that was previously accepted now fails the lint step.

### Fix

Extract the numeric literals into named constants. No runtime behaviour change.
