### PR TITLE
Fixes #462 - Tolerate cluster nodes without shared storage access

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
@@ -33,6 +33,11 @@ module ForemanFogProxmox
       storages = node.storages.list_by_content_type type
       logger.debug("storages(): node_id #{node_id} type #{type}")
       storages.reject { |s| s.enabled.to_i.zero? || s.active.to_i.zero? }.sort_by(&:storage)
+    rescue Excon::Errors::HTTPStatusError => e
+      raise unless storage_unavailable_on_node?(e)
+
+      logger.warn("storages(): skipping node #{node_id}, storage not available on this node: #{e.message}")
+      []
     end
 
     def bridges(node_id = default_node_id)
@@ -81,6 +86,14 @@ module ForemanFogProxmox
     end
 
     private
+
+    def storage_unavailable_on_node?(error)
+      response = error.response if error.respond_to?(:response)
+      response_body = response.body if response.respond_to?(:body)
+      error_text = [error.message, response_body].compact.join("\n")
+
+      error_text.match?(/storage\b.*\bnot available on node\b|storage_check_node/i)
+    end
 
     def attach_compute_resource_id(virtual_machine)
       return virtual_machine if virtual_machine.nil?

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_queries_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_queries_test.rb
@@ -97,6 +97,34 @@ module ForemanFogProxmox
 
         assert_empty @cr.storages('proxmox')
       end
+
+      it 'returns empty when the storage is not available on the node (no shared storage access)' do
+        response = OpenStruct.new(body: "storage 'ceph' is not available on node 'proxmox'")
+        error = Excon::Errors::InternalServerError.new('500 Internal Server Error', nil, response)
+        @storages_collection.stubs(:list_by_content_type).with('images').raises(error)
+
+        assert_empty @cr.storages('proxmox')
+      end
+
+      it 're-raises an authentication error instead of silently emptying the storage list' do
+        error = Excon::Errors::Unauthorized.new('401 Unauthorized: authentication failure')
+        @storages_collection.stubs(:list_by_content_type).with('images').raises(error)
+
+        assert_raises(Excon::Errors::Unauthorized) { @cr.storages('proxmox') }
+      end
+
+      it 're-raises an unexpected server error that is not a not-available case' do
+        error = Excon::Errors::InternalServerError.new('API endpoint is not available')
+        @storages_collection.stubs(:list_by_content_type).with('images').raises(error)
+
+        assert_raises(Excon::Errors::InternalServerError) { @cr.storages('proxmox') }
+      end
+
+      it 'does not swallow generic (non-HTTP) errors' do
+        @storages_collection.stubs(:list_by_content_type).with('images').raises(StandardError.new('boom'))
+
+        assert_raises(StandardError) { @cr.storages('proxmox') }
+      end
     end
 
     describe 'find_vm_by_uuid' do


### PR DESCRIPTION
## Summary

Fixes #462.

In a stretched or HA Proxmox cluster, a witness node may intentionally have no access to shared storage. Storage enumeration currently raises when it reaches that node, preventing metadata and templates from healthy nodes from being returned.

## Cause

`ProxmoxVMQueries#storages` calls `node.storages.list_by_content_type` without handling the Proxmox error returned when storage is unavailable on the queried node.

This also affects callers that iterate cluster nodes, including metadata collection and `ProxmoxImages#templates`.

## Fix

Handle only the expected Proxmox storage-unavailable response:

- Inspect both the Excon exception message and response body.
- Return an empty storage list when the response identifies storage as unavailable on the queried node.
- Log the skipped node.
- Re-raise authentication errors, connection failures, generic exceptions, and unrelated HTTP errors.

No witness naming convention is assumed, and network or bridge errors are not suppressed.

## Tests

- Returns an empty list when the response body reports storage unavailable on the node.
- Re-raises authentication errors.
- Re-raises unrelated HTTP server errors, including generic “not available” errors.
- Does not swallow non-HTTP exceptions.

## Relation to #505

#505 queries storages for every cluster node. Returning an empty list for an expected storage-less witness allows metadata from healthy nodes to remain available without hiding unrelated failures.

#508 should be merged before #505.

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Claude (Cowork). The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
