### PR TITLE
Refs #488 - Pass target node to clone for cross-host image-based deployment

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_images.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_images.rb
@@ -70,9 +70,11 @@ module ForemanFogProxmox
       find_vm_by_uuid(uuid)
     end
 
-    def clone_from_image(image, vmid)
-      logger.debug("create_vm(): clone #{image.identity} in #{vmid}")
-      image.clone(vmid)
+    def clone_from_image(image, vmid, target_node: nil)
+      logger.debug("create_vm(): clone #{image.identity} in #{vmid} target_node=#{target_node}")
+      clone_options = {}
+      clone_options[:target] = target_node if target_node && target_node != image.node_id
+      image.clone(vmid, clone_options)
       find_vm_by_uuid(id.to_s + '_' + vmid.to_s)
     end
   end

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -41,7 +41,7 @@ module ForemanFogProxmox
       if image_id
         image = find_vm_by_uuid(image_id)
         validate_image_template_disk_slots!(image, args) if type == 'qemu'
-        vm = clone_from_image(image, vmid)
+        vm = clone_from_image(image, vmid, target_node: node.node)
         vm.update(compute_clone_attributes(args, vm.container?, type, image: image))
         update_pool(vm, args[:pool]) if args[:pool]
       else

--- a/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
@@ -29,18 +29,27 @@ module ForemanFogProxmox
         @cr = FactoryBot.build_stubbed(:proxmox_cr)
         @vmid = 101
         @image = mock('vm', identity: '100')
-        @image.expects(:clone)
+        @image.stubs(:node_id).returns('pve1')
         @clone = mock('vm')
-      end
-      it 'clones server from image' do
-        @clone.stubs(:container?).returns(false)
         @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
-        @cr.clone_from_image(@image, @vmid)
       end
-      it 'clones container from image' do
-        @clone.stubs(:container?).returns(true)
-        @cr.stubs(:find_vm_by_uuid).with(@cr.id.to_s + '_' + @vmid.to_s).returns(@clone)
-        @cr.clone_from_image(@image, @vmid)
+
+      it 'passes the target node to the clone call so image deployment works across hosts' do
+        @image.expects(:clone).with(@vmid, { target: 'pve2' })
+
+        assert_equal @clone, @cr.clone_from_image(@image, @vmid, target_node: 'pve2')
+      end
+
+      it 'omits the target for a same-node deploy so local-storage templates keep working' do
+        @image.expects(:clone).with(@vmid, {})
+
+        assert_equal @clone, @cr.clone_from_image(@image, @vmid, target_node: 'pve1')
+      end
+
+      it 'omits the target when no node is given' do
+        @image.expects(:clone).with(@vmid, {})
+
+        assert_equal @clone, @cr.clone_from_image(@image, @vmid)
       end
     end
   end

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
@@ -301,7 +301,7 @@ module ForemanFogProxmox
         vm = mock('vm')
         image = mock('image')
         cr.stubs(:find_vm_by_uuid).with('999').returns(image)
-        cr.expects(:clone_from_image).with(image, 100).returns(vm)
+        cr.expects(:clone_from_image).with(image, 100, target_node: 'proxmox').returns(vm)
         vm.expects(:container?).returns(true)
         expected_args = { :vmid => "100", :type => "lxc" }
         cr.stubs(:parse_typed_vm).with(args, 'lxc').returns(expected_args)

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_server_create_test.rb
@@ -122,7 +122,7 @@ module ForemanFogProxmox
         vm = mock('vm')
         image = mock('image', config: mock('config', disks: []))
         cr.stubs(:find_vm_by_uuid).with('999').returns(image)
-        cr.expects(:clone_from_image).with(image, 100).returns(vm)
+        cr.expects(:clone_from_image).with(image, 100, target_node: 'proxmox').returns(vm)
         vm.expects(:container?).returns(false)
         expected_args = { :vmid => "100", :type => "qemu", :name => "name" }
         cr.stubs(:parse_typed_vm).with(args, 'qemu').returns(expected_args)
@@ -138,7 +138,7 @@ module ForemanFogProxmox
         cr = mock_node_servers_containers(ForemanFogProxmox::Proxmox.new, servers, containers)
         image = mock('image', config: mock('config', disks: []))
         vm = mock('vm')
-        cr.expects(:clone_from_image).with(image, 100).returns(vm)
+        cr.expects(:clone_from_image).with(image, 100, target_node: 'proxmox').returns(vm)
         vm.expects(:container?).returns(false)
         cr.expects(:parse_cloudinit_config).never
         cr.expects(:find_vm_by_uuid).with('999').once.returns(image)


### PR DESCRIPTION
## Summary

Addresses Cause 1 from #488. This PR intentionally uses `Refs` and does not close the issue because the cloud-init placement problem remains separate.

Image-based deployment failed when a template lived on one Proxmox node and the target VM was assigned to another. `clone_from_image` called the clone API without `target`, so Proxmox placed the clone on the template's node.

## Changes

- Add an optional `target_node:` keyword to `clone_from_image`.
- Pass the node selected for the new VM from `create_vm`.
- Forward `target` to the Proxmox clone API only when the selected node differs from the template node.
- Omit `target` for same-node deployment so templates on local storage keep their previous behavior.

Cross-node cloning through `target` requires the source template to be on storage shared with the destination node. Proxmox does not allow the `target` option for a template on local-only storage.

## Scope

This PR fixes only Cause 1 from #488.

Cause 2 — placing the cloud-init ISO on the template node instead of the selected target node — remains open. #495 contains a broader SSH change that also targets cloud-init operations at `args[:node_id]`, but it has not been merged yet.

## Relation to #494

#494 adds a `full_clone:` keyword to the same clone path. The options are independent and can be combined as:

```ruby
def clone_from_image(image, vmid, full_clone: false, target_node: nil)
```

The branches will require a small manual merge if both remain open. Full cloning does not remove Proxmox's requirement that a cross-node clone using `target` starts from shared storage.

## Tests

- Passes `target` for a different destination node.
- Omits `target` for same-node deployment.
- Omits `target` when no destination node is supplied.
- Verifies that QEMU and LXC creation pass the selected node as a keyword argument.

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Claude (Cowork). The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
