### PR TITLE
Fixes #510 - Add arm64/armhf to LXC architecture options

### DIFF
--- a/app/helpers/proxmox_compute_selectors_helper.rb
+++ b/app/helpers/proxmox_compute_selectors_helper.rb
@@ -24,8 +24,10 @@ module ProxmoxComputeSelectorsHelper
   end
 
   def proxmox_archs_map
-    [OpenStruct.new(id: 'amd64', name: '64 bits'),
-     OpenStruct.new(id: 'i386', name: '32 bits')]
+    [OpenStruct.new(id: 'amd64', name: 'amd64 (64-bit x86)'),
+     OpenStruct.new(id: 'i386', name: 'i386 (32-bit x86)'),
+     OpenStruct.new(id: 'arm64', name: 'arm64 (64-bit ARM)'),
+     OpenStruct.new(id: 'armhf', name: 'armhf (32-bit ARM)')]
   end
 
   def proxmox_ostypes_map

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_compute_selectors_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_compute_selectors_helper_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Tristan Robert
+
+# This file is part of ForemanFogProxmox.
+
+# ForemanFogProxmox is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# ForemanFogProxmox is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>.
+
+require 'test_plugin_helper'
+
+module ForemanFogProxmox
+  class ProxmoxComputeSelectorsHelperTest < ActiveSupport::TestCase
+    include ProxmoxComputeSelectorsHelper
+
+    describe 'proxmox_archs_map' do
+      it 'returns the supported LXC architectures' do
+        expected = [
+          ['amd64', 'amd64 (64-bit x86)'],
+          ['i386', 'i386 (32-bit x86)'],
+          ['arm64', 'arm64 (64-bit ARM)'],
+          ['armhf', 'armhf (32-bit ARM)'],
+        ]
+        actual = proxmox_archs_map.map { |arch| [arch.id, arch.name] }
+
+        assert_equal expected, actual
+      end
+    end
+  end
+end

--- a/webpack/components/ProxmoxComputeSelectors.js
+++ b/webpack/components/ProxmoxComputeSelectors.js
@@ -20,8 +20,10 @@ const ProxmoxComputeSelectors = {
   ],
 
   proxmoxArchsMap: [
-    { value: 'amd64', label: '64 bits' },
-    { value: 'i386', label: '32 bits' },
+    { value: 'amd64', label: 'amd64 (64-bit x86)' },
+    { value: 'i386', label: 'i386 (32-bit x86)' },
+    { value: 'arm64', label: 'arm64 (64-bit ARM)' },
+    { value: 'armhf', label: 'armhf (32-bit ARM)' },
   ],
 
   proxmoxOstypesMap: [

--- a/webpack/components/__tests__/ProxmoxComputeSelectors.test.js
+++ b/webpack/components/__tests__/ProxmoxComputeSelectors.test.js
@@ -22,6 +22,15 @@ describe('ProxmoxComputeSelectors', () => {
     expect(values).not.toContain('');
   });
 
+  it('contains the supported LXC architectures', () => {
+    expect(ProxmoxComputeSelectors.proxmoxArchsMap).toEqual([
+      { value: 'amd64', label: 'amd64 (64-bit x86)' },
+      { value: 'i386', label: 'i386 (32-bit x86)' },
+      { value: 'arm64', label: 'arm64 (64-bit ARM)' },
+      { value: 'armhf', label: 'armhf (32-bit ARM)' },
+    ]);
+  });
+
   it('builds HDD controllers map from cloudinit controllers plus virtio', () => {
     const cloudinitValues = ProxmoxComputeSelectors.proxmoxControllersCloudinitMap.map(
       v => v.value


### PR DESCRIPTION
## Summary

Fixes #510.

The LXC architecture selector only offered `amd64` and `i386`, although Proxmox also supports ARM containers.

## Changes

- Add `arm64` and `armhf` to the legacy Ruby selector.
- Add the same values to the React selector.
- Use consistent labels in both interfaces:
  - `amd64 (64-bit x86)`
  - `i386 (32-bit x86)`
  - `arm64 (64-bit ARM)`
  - `armhf (32-bit ARM)`

The selected `arch` value already passes through to Proxmox and is declared by the fog-proxmox container model, so no fog-proxmox change is required.

## Tests

- Verify the Ruby architecture map.
- Verify the React architecture map.

## Scope

Recent Proxmox versions also expose `riscv32` and `riscv64`. Those values remain intentionally excluded because this change addresses the ARM use case reported in #510.

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Claude (Cowork). The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
