### PR TITLE
Fixes #512 - Add unprivileged option for LXC containers

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -78,7 +78,9 @@ module ForemanFogProxmox
         options = { :hostname => args[:name] }
         parsed_args.merge(options)
       end
-      parsed_args.reject { |k| k == 'pool' }
+      # LXC clones inherit the privilege mode from the source template.
+      excluded_keys = [:pool, :unprivileged]
+      parsed_args.reject { |key, _value| excluded_keys.include?(key.to_sym) }
     end
 
     def destroy_vm(uuid)
@@ -101,7 +103,7 @@ module ForemanFogProxmox
 
     def compute_config_attributes(parsed_attr)
       excluded_keys = [:vmid, :templated, :ostemplate, :ostemplate_file, :ostemplate_storage, :volumes_attributes,
-                       :pool]
+                       :pool, :unprivileged]
       config_attributes = parsed_attr.reject { |key, _value| excluded_keys.include? key.to_sym }
       ForemanFogProxmox::HashCollection.remove_empty_values(config_attributes)
       config_attributes = config_attributes.reject { |key, _value| Fog::Proxmox::DiskHelper.disk?(key) }

--- a/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_new.rb
@@ -157,6 +157,7 @@ module ForemanFogProxmox
         config_attributes = {
           memory: '1024',
           templated: '0',
+          unprivileged: '1',
         }
       end
       config_attributes

--- a/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
@@ -22,6 +22,7 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <div class="accordion-content">
   <%= textarea_f f, :description, :label => _('Description'), :label_size => "col-md-2" %>
   <%= checkbox_f f, :onboot, :label => _('Start at boot') %>
+  <%= checkbox_f f, :unprivileged, :label => _('Unprivileged container'), :disabled => !new_vm %>
   </div>
 <% end %>
 <%= field_set_tag _("CPU"), :id => "container_config_cpu", :class => 'accordion-section', :disabled => !container do %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -40,6 +40,7 @@ module ForemanFogProxmox
           'password' => 'proxmox01',
           'config_attributes' => {
             'onboot' => '0',
+            'unprivileged' => '1',
             'description' => '',
             'memory' => '1024',
             'swap' => '512',
@@ -95,6 +96,7 @@ module ForemanFogProxmox
           :memory => '1024',
           'templated' => '0',
           :onboot => '0',
+          :unprivileged => '1',
           :swap => '512',
           'cores' => '1',
           :arch => 'amd64',
@@ -147,6 +149,7 @@ module ForemanFogProxmox
           :password => 'proxmox01',
           :ostemplate => 'local:vztmpl/alpine-3.7-default_20171211_amd64.tar.xz',
           :onboot => '0',
+          :unprivileged => '1',
           :memory => '1024',
           :swap => '512',
           :cores => '1',

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
@@ -56,7 +56,7 @@ module ForemanFogProxmox
         @cr.save_vm(uuid, attr)
       end
 
-      it 'saves modified container config' do
+      it 'saves modified container config without changing privilege mode' do
         uuid = '100'
         config = mock('config')
         config.stubs(:attributes).returns(:cores => '')
@@ -69,7 +69,8 @@ module ForemanFogProxmox
         vm.stubs(:attributes).returns(node_id: 'proxmox', type: 'lxc')
         @cr.stubs(:find_vm_by_uuid).returns(vm)
         attr = { 'templated' => '0', 'node_id' => 'proxmox',
-                 'config_attributes' => { 'cores' => '1', 'cpulimit' => '1', 'onboot' => '0' } }.with_indifferent_access
+                 'config_attributes' => { 'cores' => '1', 'cpulimit' => '1', 'onboot' => '0',
+                                          'unprivileged' => '1' } }.with_indifferent_access
         @cr.stubs(:parse_container_vm).returns('vmid' => '100', 'node_id' => 'proxmox', 'type' => 'lxc',
           'cores' => '1', 'cpulimit' => '1')
         expected_attr = { :cores => '1', :cpulimit => '1' }
@@ -252,8 +253,8 @@ module ForemanFogProxmox
     end
 
     describe 'create_vm' do
-      it 'creates container without bootstart' do
-        args = { vmid: '100', type: 'lxc', node_id: 'proxmox', start_after_create: '0' }
+      it 'creates an unprivileged container without bootstart' do
+        args = { vmid: '100', type: 'lxc', node_id: 'proxmox', start_after_create: '0', unprivileged: '1' }
         servers = mock('servers')
         servers.stubs(:id_valid?).returns(true)
         containers = mock('containers')
@@ -303,8 +304,9 @@ module ForemanFogProxmox
         cr.stubs(:find_vm_by_uuid).with('999').returns(image)
         cr.expects(:clone_from_image).with(image, 100).returns(vm)
         vm.expects(:container?).returns(true)
-        expected_args = { :vmid => "100", :type => "lxc" }
-        cr.stubs(:parse_typed_vm).with(args, 'lxc').returns(expected_args)
+        parsed_args = { vmid: '100', type: 'lxc', unprivileged: '1' }
+        cr.stubs(:parse_typed_vm).with(args, 'lxc').returns(parsed_args)
+        expected_args = { vmid: '100', type: 'lxc' }
         vm.expects(:update).with(expected_args)
         cr.create_vm(args)
       end

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
@@ -14,6 +14,7 @@ const ProxmoxContainerOptions = ({
   computeResourceId,
   newVm,
   fromProfile,
+  imageBased,
 }) => {
   const [opts, setOpts] = useState(options);
   const storagesMap = createStoragesMap(storages, 'vztmpl', nodeId);
@@ -136,6 +137,22 @@ const ProxmoxContainerOptions = ({
         onChange={handleChange}
       />
       <InputField
+        name={opts?.unprivileged?.name}
+        label={__('Unprivileged container')}
+        info={
+          imageBased
+            ? __(
+                'Image-based deployments inherit this setting from the selected template.'
+              )
+            : undefined
+        }
+        type="checkbox"
+        value={opts?.unprivileged?.value}
+        checked={String(opts?.unprivileged?.value) === '1'}
+        disabled={isEditMode || imageBased}
+        onChange={handleChange}
+      />
+      <InputField
         name={opts?.ostype?.name}
         label={__('OS Type')}
         type="select"
@@ -173,6 +190,7 @@ ProxmoxContainerOptions.propTypes = {
   computeResourceId: PropTypes.number,
   newVm: PropTypes.bool,
   fromProfile: PropTypes.bool,
+  imageBased: PropTypes.bool,
 };
 
 ProxmoxContainerOptions.defaultProps = {
@@ -182,6 +200,7 @@ ProxmoxContainerOptions.defaultProps = {
   computeResourceId: null,
   newVm: false,
   fromProfile: false,
+  imageBased: false,
 };
 
 export default ProxmoxContainerOptions;

--- a/webpack/components/ProxmoxVmType.js
+++ b/webpack/components/ProxmoxVmType.js
@@ -250,6 +250,9 @@ const ProxmoxVmType = ({
           computeResourceId={computeResourceId}
           newVm={newVm}
           fromProfile={fromProfile}
+          imageBased={
+            provisionMethodState === 'image' || Boolean(general?.imageId?.value)
+          }
         />
       ),
       hardware: <ProxmoxContainerHardware hardware={vmAttrs} />,

--- a/webpack/components/__tests__/ProxmoxContainerOptions.test.js
+++ b/webpack/components/__tests__/ProxmoxContainerOptions.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ProxmoxContainerOptions from '../ProxmoxContainer/ProxmoxContainerOptions';
+
+jest.mock('../ProxmoxStoragesUtils', () => ({
+  createStoragesMap: () => [],
+  imagesByStorage: () => [],
+}));
+
+jest.mock('../hooks/useVolumes', () => () => ({
+  volumes: [],
+  loadingVolumes: false,
+  volumeError: null,
+}));
+
+describe('ProxmoxContainerOptions', () => {
+  const options = {
+    ostemplateStorage: { name: 'storage', value: 'local' },
+    ostemplateFile: { name: 'ostemplate', value: '' },
+    password: { name: 'password', value: '' },
+    onboot: { name: 'onboot', value: '0' },
+    unprivileged: { name: 'unprivileged', value: '1' },
+    ostype: { name: 'ostype', value: 'debian' },
+    hostname: { name: 'hostname', value: '' },
+    nameserver: { name: 'nameserver', value: '' },
+    searchdomain: { name: 'searchdomain', value: '' },
+  };
+
+  it('enables the unprivileged option for direct container creation', () => {
+    const { container } = render(
+      <ProxmoxContainerOptions options={options} newVm />
+    );
+
+    const checkbox = container.querySelector('input[name="unprivileged"]');
+    expect(checkbox).toBeEnabled();
+    expect(checkbox).toBeChecked();
+  });
+
+  it('disables the unprivileged option when editing a container', () => {
+    const { container } = render(
+      <ProxmoxContainerOptions options={options} />
+    );
+
+    expect(
+      container.querySelector('input[name="unprivileged"]')
+    ).toBeDisabled();
+  });
+
+  it('disables the unprivileged option for image-based deployment', async () => {
+    const { container } = render(
+      <ProxmoxContainerOptions options={options} newVm imageBased />
+    );
+
+    const checkbox = container.querySelector('input[name="unprivileged"]');
+    expect(checkbox).toBeDisabled();
+    fireEvent.click(container.querySelector('.field-help'));
+    expect(
+      await screen.findByText(
+        'Image-based deployments inherit this setting from the selected template.'
+      )
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #512.

Adds an **Unprivileged container** checkbox to the LXC options and serializes it to the Proxmox `unprivileged` attribute. New containers default to `unprivileged=1`, matching the Proxmox VE GUI and its recommended security posture. Uncheck the option to create a privileged container.

The option is available only for direct container creation. Image-based deployments inherit the privilege mode from the selected LXC template because the Proxmox clone API does not accept `unprivileged`. The field is also disabled when editing an existing container, and the backend excludes it from update requests because Proxmox warns against changing this setting after creation.

`unprivileged` is already declared by fog-proxmox, so no fog-proxmox change is required.

Tests cover default serialization, direct creation, clone and update filtering, and the disabled form states.

_Drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
