### PR TITLE
Fixes #514 - Add SSH public keys for LXC and make root password optional

### DIFF
--- a/app/helpers/proxmox_vm_config_helper.rb
+++ b/app/helpers/proxmox_vm_config_helper.rb
@@ -119,7 +119,20 @@ module ProxmoxVMConfigHelper
     parsed_vm = args.reject { |key, value| args_a(type).include?(key) || ForemanFogProxmox::Value.empty?(value) }
     parsed_vm = parsed_vm.merge(config_options(config, args, type))
     parsed_vm = parsed_vm.merge(parsed_config).merge(cpu).merge(memory)
+    parsed_vm = parse_container_sshkeys(parsed_vm) if type == 'lxc'
     logger.debug("parsed_typed_config(#{type}): parsed_vm=#{parsed_vm}")
+    parsed_vm
+  end
+
+  # LXC does not use cloud-init: it takes SSH public keys via the pct
+  # 'ssh-public-keys' config key (note the hyphens). The form and config use
+  # the 'sshkeys' key (mirroring qemu), so rename it to the hyphenated pct key
+  # before it is passed to fog create. This key is write-only/create-only.
+  def parse_container_sshkeys(parsed_vm)
+    return parsed_vm unless parsed_vm.key?('sshkeys')
+
+    sshkeys = parsed_vm.delete('sshkeys')
+    parsed_vm.store('ssh-public-keys', sshkeys) unless ForemanFogProxmox::Value.empty?(sshkeys)
     parsed_vm
   end
 

--- a/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_compute_attributes.rb
@@ -30,6 +30,7 @@ module ForemanFogProxmox
       case type
       when 'lxc'
         host.compute_attributes['config_attributes'].store('hostname', host.name)
+        ensure_container_login!(host, config['sshkeys'])
       when 'qemu'
         host.compute_attributes['config_attributes'].store('name', host.name)
         unless compute_os_types(host).include?(ostype)
@@ -39,6 +40,17 @@ module ForemanFogProxmox
         end
       end
       super
+    end
+
+    # The root password and the SSH public keys are both optional on the form, but a
+    # new container needs at least one of them, otherwise it is provisioned with no way
+    # to log in. Enforce this only when creating a new host (both are create-only params
+    # that are not stored on the VM, so they are legitimately absent when editing).
+    def ensure_container_login!(host, sshkeys)
+      return unless host.new_record?
+      return unless ForemanFogProxmox::Value.empty?(host.compute_attributes['password']) && ForemanFogProxmox::Value.empty?(sshkeys)
+
+      raise ::Foreman::Exception, _('A new container requires a root password or SSH public keys to be able to log in')
     end
 
     def not_config_key?(vm, key)

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -71,7 +71,11 @@ module ForemanFogProxmox
         options = { :hostname => args[:name] }
         parsed_args.merge(options)
       end
-      parsed_args.reject { |k| k == 'pool' }
+      # The root 'password' and 'ssh-public-keys' (raw 'sshkeys') are create-only
+      # container params: PVE rejects them on PUT .../lxc/{vmid}/config, so they must be
+      # kept out of the clone/update body (mirrors how 'pool' is excluded here).
+      excluded_keys = ['pool', 'password', 'sshkeys', 'ssh-public-keys']
+      parsed_args.reject { |k| excluded_keys.include?(k.to_s) }
     end
 
     def destroy_vm(uuid)
@@ -93,8 +97,10 @@ module ForemanFogProxmox
     end
 
     def compute_config_attributes(parsed_attr)
+      # The root 'password' and 'ssh-public-keys' (raw 'sshkeys') are create-only, like
+      # 'ostemplate': PVE rejects them on PUT .../config, so exclude them from updates.
       excluded_keys = [:vmid, :templated, :ostemplate, :ostemplate_file, :ostemplate_storage, :volumes_attributes,
-                       :pool]
+                       :pool, :password, :sshkeys, :'ssh-public-keys']
       config_attributes = parsed_attr.reject { |key, _value| excluded_keys.include? key.to_sym }
       ForemanFogProxmox::HashCollection.remove_empty_values(config_attributes)
       config_attributes = config_attributes.reject { |key, _value| Fog::Proxmox::DiskHelper.disk?(key) }

--- a/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
@@ -50,3 +50,8 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <%= select_f f, :ostype, proxmox_ostypes_map, :id, :name, { }, :label => _('OS type'), :label_size => "col-md-2" %>
   </div>
 <% end %>
+<%= field_set_tag _("SSH"), :id => "container_config_ssh", :class => 'accordion-section', :disabled => !container do %>
+  <div class="accordion-content">
+  <%= textarea_f f, :sshkeys, :label => _("SSH public keys"), :size => "col-md-4" %>
+  </div>
+<% end %>

--- a/app/views/compute_resources_vms/form/proxmox/container/_extended.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_extended.html.erb
@@ -23,5 +23,5 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
     <%= select_f f, :ostemplate_storage, compute_resource.storages(node_id,'vztmpl'), :storage, :storage, { :include_blank => true }, :disabled => !new_vm, :class => ('hide' unless new_vm), :label => _('Template storage'), :label_size => "col-md-2", :onchange => 'storageOstemplateSelected(this)' %>
     <%= select_f f, :ostemplate_file, compute_resource.images_by_storage(node_id,f.object.ostemplate_storage, 'vztmpl'), :volid, :volid, { :include_blank => true }, :disabled => !new_vm, :class => ('hide' unless new_vm), :label => _('OS Template'), :label_size => "col-md-2", :required => true %>
   </div>
-  <%= password_proxmox_f f, :password, :label => _("Root password"), :required => true %>
+  <%= password_proxmox_f f, :password, :label => _("Root password") %>
 <% end %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -161,6 +161,18 @@ module ForemanFogProxmox
         assert_equal expected_vm, vm
       end
 
+      test '#vm container with ssh public keys' do
+        ssh_form = host_form.merge(
+          'config_attributes' => host_form['config_attributes'].merge(
+            'sshkeys' => 'ssh-rsa AAAAB3NzaC1 user@host'
+          )
+        )
+        vm = parse_typed_vm(ssh_form, type)
+        assert vm.key?('ssh-public-keys')
+        assert_equal 'ssh-rsa AAAAB3NzaC1 user@host', vm['ssh-public-keys']
+        assert_not vm.key?('sshkeys')
+      end
+
       test '#volume with rootfs 1Gb' do
         volumes = parse_typed_volumes(host_form['volumes_attributes'], type)
         assert_not volumes.empty?

--- a/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_compute_attributes_test.rb
@@ -114,6 +114,7 @@ module ForemanFogProxmox
           :interfaces => [physical_nic],
           :compute_attributes => {
             'type' => 'lxc',
+            'password' => 'proxmox01',
             'config_attributes' => {
               'hostname' => '',
             },
@@ -124,6 +125,52 @@ module ForemanFogProxmox
         )
         @cr.host_compute_attrs(host)
         assert_equal host.name, host.compute_attributes['config_attributes']['hostname']
+      end
+
+      it 'accepts a container with only SSH public keys and no root password' do
+        physical_nic = FactoryBot.build(:nic_base_empty, :identifier => 'net0', :primary => true,
+          :compute_attributes => { 'dhcp' => '1', 'dhcp6' => '1' })
+        host = FactoryBot.build(
+          :host_empty,
+          :interfaces => [physical_nic],
+          :compute_attributes => {
+            'type' => 'lxc',
+            'password' => '',
+            'config_attributes' => {
+              'hostname' => '',
+              'sshkeys' => 'ssh-rsa AAAAB3NzaC1 user@host',
+            },
+            'interfaces_attributes' => {
+              '0' => {},
+            },
+          }
+        )
+        @cr.host_compute_attrs(host)
+        assert_equal host.name, host.compute_attributes['config_attributes']['hostname']
+      end
+
+      it 'raises Foreman::Exception for a container without a root password nor SSH public keys' do
+        physical_nic = FactoryBot.build(:nic_base_empty, :identifier => 'net0', :primary => true,
+          :compute_attributes => { 'dhcp' => '1', 'dhcp6' => '1' })
+        host = FactoryBot.build(
+          :host_empty,
+          :interfaces => [physical_nic],
+          :compute_attributes => {
+            'type' => 'lxc',
+            'password' => '',
+            'config_attributes' => {
+              'hostname' => '',
+              'sshkeys' => '',
+            },
+            'interfaces_attributes' => {
+              '0' => {},
+            },
+          }
+        )
+        err = assert_raises Foreman::Exception do
+          @cr.host_compute_attrs(host)
+        end
+        assert err.message.end_with?('A new container requires a root password or SSH public keys to be able to log in')
       end
     end
 

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
@@ -306,6 +306,40 @@ module ForemanFogProxmox
         vm.expects(:update).with(expected_args)
         cr.create_vm(args)
       end
+
+      it 'excludes the create-only password and ssh keys from the clone/update attributes' do
+        cr = ForemanFogProxmox::Proxmox.new
+        args = { vmid: '100', type: 'lxc', image_id: '999', name: 'name' }
+        cr.stubs(:parse_typed_vm).with(args, 'lxc').returns(
+          'vmid' => '100',
+          'type' => 'lxc',
+          'pool' => 'pool1',
+          'password' => 'secret',
+          'sshkeys' => 'ssh-rsa AAAAB3NzaC1 user@host',
+          'ssh-public-keys' => 'ssh-rsa AAAAB3NzaC1 user@host'
+        )
+        clone_attributes = cr.compute_clone_attributes(args, true, 'lxc')
+        assert_not clone_attributes.key?('ssh-public-keys')
+        assert_not clone_attributes.key?('sshkeys')
+        assert_not clone_attributes.key?('password')
+        assert_not clone_attributes.key?('pool')
+        assert_equal '100', clone_attributes['vmid']
+      end
+
+      it 'excludes the create-only password and ssh keys from the container update config' do
+        cr = ForemanFogProxmox::Proxmox.new
+        parsed_attr = {
+          'cores' => '1',
+          'password' => 'secret',
+          'sshkeys' => 'ssh-rsa AAAAB3NzaC1 user@host',
+          'ssh-public-keys' => 'ssh-rsa AAAAB3NzaC1 user@host',
+        }
+        config_attributes = cr.compute_config_attributes(parsed_attr)[:config_attributes]
+        assert_not config_attributes.key?('ssh-public-keys')
+        assert_not config_attributes.key?('sshkeys')
+        assert_not config_attributes.key?('password')
+        assert_equal '1', config_attributes['cores']
+      end
     end
   end
 end

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
@@ -122,9 +122,15 @@ const ProxmoxContainerOptions = ({
       <InputField
         name={opts?.password?.name}
         label={__('Root Password')}
-        required
         type="password"
         value={opts?.password?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.sshkeys?.name}
+        label={__('SSH public keys')}
+        type="textarea"
+        value={opts?.sshkeys?.value}
         onChange={handleChange}
       />
       <InputField


### PR DESCRIPTION
Fixes #514.

Adds an **SSH public keys** field to the LXC form (serialised to the pct `ssh-public-keys` key on create) and makes the root **password** optional, so containers can be provisioned with key-based access instead of a mandatory password. `ssh-public-keys` is create-only / write-only (not returned by the config API), so this is plugin-only — no `fog-proxmox` change.

Includes a unit test in `proxmox_container_helper_test.rb`.

_Drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
