### PR TITLE
Fixes #515 - Add LXC startup/shutdown ordering (order/up/down)

### DIFF
--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -128,13 +128,17 @@ module ProxmoxVMAttrsHelper
       nameserver: vms.config.nameserver,
       searchdomain: vms.config.searchdomain,
       hostname: vms.config.hostname,
+      startup_order: vms.config.startup_order,
+      startup_up: vms.config.startup_up,
+      startup_down: vms.config.startup_down,
       ostemplate_storage: vms.ostemplate_storage,
       ostemplate_file: vms.ostemplate_file,
       start_after_create: vms.start_after_create,
       templated: vms.templated,
       is_secure_boot: vms.config.secure_boot?,
     }
-    vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname, :is_secure_boot]
+    vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname,
+                :is_secure_boot, :startup_order, :startup_up, :startup_down]
     extra_attrs = ActiveSupport::HashWithIndifferentAccess.new
     attributes.each do |key, value|
       camel_key = key.to_s.include?('_') ? snake_to_camel(key.to_s).to_sym : key

--- a/app/helpers/proxmox_vm_config_helper.rb
+++ b/app/helpers/proxmox_vm_config_helper.rb
@@ -115,14 +115,28 @@ module ProxmoxVMConfigHelper
     logger.debug("parsed_typed_config(#{type}): config_cpu=#{config_cpu}")
     cpu = parse_typed_cpu(config_cpu, type)
     memory = parse_typed_memory(config.select { |key, _value| config_typed_keys(type)[:memory].include? key }, type)
+    startup = parse_typed_startup(config)
     parsed_config = config.reject do |key, value|
-      config_a(type).include?(key) || ForemanFogProxmox::Value.empty?(value)
+      config_a(type).include?(key) || startup_keys.include?(key) || ForemanFogProxmox::Value.empty?(value)
     end
     parsed_vm = args.reject { |key, value| args_a(type).include?(key) || ForemanFogProxmox::Value.empty?(value) }
     parsed_vm = parsed_vm.merge(config_options(config, args, type))
-    parsed_vm = parsed_vm.merge(parsed_config).merge(cpu).merge(memory)
+    parsed_vm = parsed_vm.merge(parsed_config).merge(cpu).merge(memory).merge(startup)
     logger.debug("parsed_typed_config(#{type}): parsed_vm=#{parsed_vm}")
     parsed_vm
+  end
+
+  def startup_keys
+    ['startup_order', 'startup_up', 'startup_down']
+  end
+
+  # Serialise the order/up/down form fields into a single Proxmox 'startup'
+  # config value of the form 'order=1,up=30,down=30' (empty sub-parts omitted).
+  def parse_typed_startup(config)
+    parts = { order: config['startup_order'], up: config['startup_up'], down: config['startup_down'] }
+    startup = parts.reject { |_key, value| ForemanFogProxmox::Value.empty?(value) }
+                   .map { |key, value| "#{key}=#{value}" }.join(',')
+    ForemanFogProxmox::Value.empty?(startup) ? {} : { startup: startup }
   end
 
   def parse_typed_memory(args, type)

--- a/app/models/concerns/fog_extensions/proxmox/server_config.rb
+++ b/app/models/concerns/fog_extensions/proxmox/server_config.rb
@@ -53,6 +53,31 @@ module FogExtensions
         secure_boot = bios == 'ovmf' && Foreman::Cast.to_bool(efidisk&.pre_enrolled_keys)
         Foreman::Cast.to_bool(secure_boot) ? '1' : '0'
       end
+
+      def startup_order
+        startup_options['order']
+      end
+
+      def startup_up
+        startup_options['up']
+      end
+
+      def startup_down
+        startup_options['down']
+      end
+
+      private
+
+      # Parse the Proxmox 'startup' string (e.g. 'order=1,up=30,down=30')
+      # into a hash so the boot/shutdown ordering fields round-trip on read.
+      def startup_options
+        return {} if startup.nil? || startup == ''
+
+        startup.to_s.split(',').each_with_object({}) do |part, options|
+          key, value = part.split('=', 2)
+          options[key] = value
+        end
+      end
     end
   end
 end

--- a/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
@@ -22,6 +22,9 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <div class="accordion-content">
   <%= textarea_f f, :description, :label => _('Description'), :label_size => "col-md-2" %>
   <%= checkbox_f f, :onboot, :label => _('Start at boot') %>
+  <%= text_f f, :startup_order, :class => "input-mini", :label => _('Startup order'), :label_size => "col-md-2", :help_inline => _('Boot/shutdown ordering, e.g. order=1,up=30,down=30. Leave empty to ignore.') %>
+  <%= text_f f, :startup_up, :class => "input-mini", :label => _('Startup up delay'), :label_size => "col-md-2" %>
+  <%= text_f f, :startup_down, :class => "input-mini", :label => _('Startup down delay'), :label_size => "col-md-2" %>
   </div>
 <% end %>
 <%= field_set_tag _("CPU"), :id => "container_config_cpu", :class => 'accordion-section', :disabled => !container do %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -40,6 +40,9 @@ module ForemanFogProxmox
           'password' => 'proxmox01',
           'config_attributes' => {
             'onboot' => '0',
+            'startup_order' => '1',
+            'startup_up' => '30',
+            'startup_down' => '30',
             'description' => '',
             'memory' => '1024',
             'swap' => '512',
@@ -132,6 +135,22 @@ module ForemanFogProxmox
         assert_equal 'amd64', cpu[:arch]
       end
 
+      test '#startup' do
+        startup = parse_typed_startup(host_form['config_attributes'])
+        assert startup.key?(:startup)
+        assert_equal 'order=1,up=30,down=30', startup[:startup]
+      end
+
+      test '#startup omits empty sub-parts' do
+        startup = parse_typed_startup('startup_order' => '2', 'startup_up' => '', 'startup_down' => '15')
+        assert_equal 'order=2,down=15', startup[:startup]
+      end
+
+      test '#startup empty when no sub-parts' do
+        startup = parse_typed_startup('startup_order' => '', 'startup_up' => '', 'startup_down' => '')
+        assert_empty startup
+      end
+
       test '#ostemplate' do
         ostemplate = parse_container_ostemplate(host_form)
         expected_ostemplate = {
@@ -147,6 +166,7 @@ module ForemanFogProxmox
           :password => 'proxmox01',
           :ostemplate => 'local:vztmpl/alpine-3.7-default_20171211_amd64.tar.xz',
           :onboot => '0',
+          :startup => 'order=1,up=30,down=30',
           :memory => '1024',
           :swap => '512',
           :cores => '1',

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
@@ -136,6 +136,30 @@ const ProxmoxContainerOptions = ({
         onChange={handleChange}
       />
       <InputField
+        name={opts?.startupOrder?.name}
+        label={__('Startup order')}
+        info={__(
+          'Boot/shutdown ordering, e.g. order=1,up=30,down=30. Leave empty to ignore.'
+        )}
+        type="number"
+        value={opts?.startupOrder?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.startupUp?.name}
+        label={__('Startup up delay')}
+        type="number"
+        value={opts?.startupUp?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.startupDown?.name}
+        label={__('Startup down delay')}
+        type="number"
+        value={opts?.startupDown?.value}
+        onChange={handleChange}
+      />
+      <InputField
         name={opts?.ostype?.name}
         label={__('OS Type')}
         type="select"


### PR DESCRIPTION
## Summary

Fixes #515.

Proxmox LXC containers support a `startup` option that controls boot/shutdown ordering (`order=`, `up=`, `down=`), but the plugin exposed no way to set it. This adds three fields — startup order, startup up delay, startup down delay — to the container **Main options**, for both the React front-end and the legacy ERB partial.

## Changes

- `proxmox_vm_config_helper.rb`: serialise the three form fields into a single Proxmox `startup` value (`order=1,up=30,down=30`), omitting empty sub-parts. The synthetic `startup_*` keys are stripped from the raw config so only the combined `startup` string is sent.
- `fog_extensions/proxmox/server_config.rb`: parse the `startup` string back into `startup_order` / `startup_up` / `startup_down` getters so existing values round-trip on edit.
- `proxmox_vm_attrs_helper.rb`: surface the three synthetic getters in the attributes hash consumed by the React form.
- React `ProxmoxContainerOptions.js` + ERB `container/_config.html.erb`: the three input fields.

## Tests

- `#startup` serialises order/up/down into `order=1,up=30,down=30`.
- empty sub-parts are omitted (`order=2,down=15`).
- all-empty yields no `startup` key.
- full container serialisation includes the combined `startup` value.

---

_Investigated and drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
