### PR TITLE
Fixes #518 - Add MTU, VLAN trunks and link_down to LXC network interfaces

### DIFF
--- a/app/helpers/proxmox_vm_interfaces_helper.rb
+++ b/app/helpers/proxmox_vm_interfaces_helper.rb
@@ -50,7 +50,7 @@ module ProxmoxVMInterfacesHelper
     when 'qemu'
       keys += ['model', 'firewall', 'link_down', 'queues']
     when 'lxc'
-      keys += ['name', 'ip', 'ip6', 'gw', 'gw6', 'dhcp', 'dhcp6', 'cidr', 'cidr6', 'firewall']
+      keys += ['name', 'ip', 'ip6', 'gw', 'gw6', 'dhcp', 'dhcp6', 'cidr', 'cidr6', 'firewall', 'mtu', 'trunks', 'link_down']
     end
     keys
   end
@@ -118,6 +118,7 @@ module ProxmoxVMInterfacesHelper
       interface_compute_attributes_typed_keys(type).each do |key|
         ForemanFogProxmox::HashCollection.add_and_format_element(nic, key.to_sym, interface_attributes_h, key)
       end
+      nic[:trunks] = nic[:trunks].to_s.tr(',', ';') unless ForemanFogProxmox::Value.empty?(nic[:trunks])
       compute_dhcps(interface_attributes_h)
       logger.debug("add_or_delete_typed_interface(#{type}): add nic=#{nic}")
       interfaces_to_add.push(Fog::Proxmox::NicHelper.flatten(nic))

--- a/app/views/compute_resources_vms/form/proxmox/container/_network.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_network.html.erb
@@ -31,6 +31,9 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
     <%= text_f f, :gw6, :label => _('Gateway IPv6'), :label_size => "col-md-2", :disabled => dhcp6_enabled, :class => 'proxmox-gw-ipv6' %>
     <%= text_f f, :tag, :class => "input-mini", :label => _('VLAN tag'), :label_size => "col-md-2" %>
     <%= text_f f, :rate, :class => "input-mini", :label => _('Rate limit'), :label_size => "col-md-2" %>
+    <%= text_f f, :mtu, :class => "input-mini", :label => _('MTU'), :label_size => "col-md-2" %>
+    <%= text_f f, :trunks, :class => "input-mini", :label => _('VLAN Trunks'), :label_size => "col-md-2" %>
     <%= checkbox_f f, :firewall, :label => _('Firewall') %>
+    <%= checkbox_f f, :link_down, { :label => _('Disconnect') }, '1', '0' %>
     <%= select_f f, :bridge, compute_resource.bridges(node_id), :iface, :iface, { }, :label => _('Bridge'), :label_size => "col-md-2", :id => "host_interfaces_attributes_0_compute_attributes_bridge_1" %>
 <% end %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -211,6 +211,59 @@ module ForemanFogProxmox
         assert_includes interfaces_to_add,
           { net1: 'name=eth1,bridge=vmbr0,ip=dhcp,ip6=dhcp,gw=192.168.56.100,gw6=2001:0:1234::c1c0:abcd:876' }
       end
+
+      test '#interface compute attributes typed keys include mtu, trunks and link_down' do
+        keys = interface_compute_attributes_typed_keys(type)
+        assert_includes keys, 'mtu'
+        assert_includes keys, 'trunks'
+        assert_includes keys, 'link_down'
+      end
+
+      test '#interface with mtu, trunks and link_down' do
+        deletes = []
+        nics = []
+        interface_attributes = {
+          'id' => 'net0',
+          'compute_attributes' => {
+            'name' => 'eth0',
+            'bridge' => 'vmbr0',
+            'ip' => 'dhcp',
+            'ip6' => 'dhcp',
+            'gw' => '192.168.56.100',
+            'gw6' => '2001:0:1234::c1c0:abcd:876',
+            'mtu' => '1400',
+            'trunks' => '2;3;4',
+            'link_down' => '1',
+          },
+        }
+        add_or_delete_typed_interface(interface_attributes, deletes, nics, type)
+        assert_equal 1, nics.length
+        assert nics[0].key?(:net0)
+        assert_equal 'name=eth0,bridge=vmbr0,ip=dhcp,ip6=dhcp,gw=192.168.56.100,gw6=2001:0:1234::c1c0:abcd:876,mtu=1400,trunks=2;3;4,link_down=1',
+          nics[0][:net0]
+      end
+
+      test '#interface normalizes comma-separated trunks to semicolons' do
+        deletes = []
+        nics = []
+        interface_attributes = {
+          'id' => 'net0',
+          'compute_attributes' => {
+            'name' => 'eth0',
+            'bridge' => 'vmbr0',
+            'ip' => 'dhcp',
+            'ip6' => 'dhcp',
+            'gw' => '192.168.56.100',
+            'gw6' => '2001:0:1234::c1c0:abcd:876',
+            'trunks' => '10,20,30',
+          },
+        }
+        add_or_delete_typed_interface(interface_attributes, deletes, nics, type)
+        assert_equal 1, nics.length
+        assert nics[0].key?(:net0)
+        assert_equal 'name=eth0,bridge=vmbr0,ip=dhcp,ip6=dhcp,gw=192.168.56.100,gw6=2001:0:1234::c1c0:abcd:876,trunks=10;20;30',
+          nics[0][:net0]
+      end
     end
   end
 end

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerNetwork.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerNetwork.js
@@ -72,6 +72,18 @@ const ProxmoxContainerNetwork = ({ network, bridges, paramScope }) => {
           name: `${paramScope}[interfaces_attributes][${nextId}][firewall]`,
           value: '0',
         },
+        mtu: {
+          name: `${paramScope}[interfaces_attributes][${nextId}][mtu]`,
+          value: '',
+        },
+        trunks: {
+          name: `${paramScope}[interfaces_attributes][${nextId}][trunks]`,
+          value: '',
+        },
+        linkDown: {
+          name: `${paramScope}[interfaces_attributes][${nextId}][link_down]`,
+          value: '0',
+        },
       };
       const initData = {
         ...defaultData,

--- a/webpack/components/ProxmoxContainer/components/NetworkInterface.js
+++ b/webpack/components/ProxmoxContainer/components/NetworkInterface.js
@@ -171,11 +171,34 @@ const NetworkInterface = ({
         onChange={handleChange}
       />
       <InputField
+        name={network?.mtu?.name}
+        label={__('MTU')}
+        type="text"
+        value={network?.mtu?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={network?.trunks?.name}
+        label={__('VLAN Trunks')}
+        type="text"
+        value={network?.trunks?.value}
+        onChange={handleChange}
+        info={__('Semicolon-separated VLAN IDs, e.g. 10;20;30')}
+      />
+      <InputField
         name={network?.firewall?.name}
         label={__('Firewall')}
         type="checkbox"
         value={network?.firewall?.value}
         checked={String(network?.firewall?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={network?.linkDown?.name}
+        label={__('Disconnect')}
+        type="checkbox"
+        value={network?.linkDown?.value}
+        checked={String(network?.linkDown?.value) === '1'}
         onChange={handleChange}
       />
     </div>


### PR DESCRIPTION
## Summary

Fixes #518.

LXC network interfaces in Proxmox accept `mtu`, `trunks` (VLAN trunks) and `link_down` (start disconnected), but the container network form exposed only a subset of options. This adds the three fields to both the React front-end and the legacy ERB partial, and to the interface serialisation.

## Changes

- `proxmox_vm_interfaces_helper.rb`: add `mtu`, `trunks`, `link_down` to the LXC interface typed-keys so they are serialised into the `netN` string.
- React `ProxmoxContainerNetwork.js` (defaults) + `components/NetworkInterface.js` (inputs), ERB `container/_network.html.erb`: MTU and VLAN trunks text fields plus a Disconnect checkbox.

`mtu`, `trunks` and `link_down` are already declared attributes on the fog-proxmox `Interface` model, so they round-trip on read as well as on create.

## Tests

- the LXC interface typed-keys include `mtu`, `trunks`, `link_down`.
- an interface with all three serialises to the expected `netN` string.

---

_Investigated and drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
