### PR TITLE
Fixes #519 - Add LXC console options (cmode, tty, console)

### DIFF
--- a/app/helpers/proxmox_compute_selectors_helper.rb
+++ b/app/helpers/proxmox_compute_selectors_helper.rb
@@ -28,6 +28,12 @@ module ProxmoxComputeSelectorsHelper
      OpenStruct.new(id: 'i386', name: '32 bits')]
   end
 
+  def proxmox_cmodes_map
+    [OpenStruct.new(id: 'tty', name: 'tty'),
+     OpenStruct.new(id: 'console', name: 'console'),
+     OpenStruct.new(id: 'shell', name: 'shell')]
+  end
+
   def proxmox_ostypes_map
     [OpenStruct.new(id: 'debian', name: 'Debian'),
      OpenStruct.new(id: 'ubuntu', name: 'Ubuntu'),

--- a/app/views/compute_resources_vms/form/proxmox/container/_advanced.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_advanced.html.erb
@@ -15,7 +15,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
 
-<% container = f.object.type == 'lxc' %>  
+<% container = type == 'lxc' %>
 
 <%= field_set_tag _("Advanced"), :id => "container_config_advanced_options", :class => ('hide' unless container) do %>
+  <div class="accordion-content">
+  <%= select_f f, :cmode, proxmox_cmodes_map, :id, :name, { }, :label => _('Console mode'), :label_size => "col-md-2" %>
+  <%= counter_f f, :tty, :class => "input-mini", :label => _('TTY count'), :label_size => "col-md-2" %>
+  <%= checkbox_f f, :console, :label => _('Attach console (/dev/console)') %>
+  </div>
 <% end %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -161,6 +161,16 @@ module ForemanFogProxmox
         assert_equal expected_vm, vm
       end
 
+      test '#console options' do
+        form = host_form.deep_merge(
+          'config_attributes' => { 'cmode' => 'shell', 'tty' => '2', 'console' => '1' }
+        )
+        vm = parse_typed_vm(form, type)
+        assert_equal 'shell', vm[:cmode]
+        assert_equal '2', vm[:tty]
+        assert_equal '1', vm[:console]
+      end
+
       test '#volume with rootfs 1Gb' do
         volumes = parse_typed_volumes(host_form['volumes_attributes'], type)
         assert_not volumes.empty?

--- a/webpack/components/ProxmoxComputeSelectors.js
+++ b/webpack/components/ProxmoxComputeSelectors.js
@@ -24,6 +24,12 @@ const ProxmoxComputeSelectors = {
     { value: 'i386', label: '32 bits' },
   ],
 
+  proxmoxCmodesMap: [
+    { value: 'tty', label: 'tty' },
+    { value: 'console', label: 'console' },
+    { value: 'shell', label: 'shell' },
+  ],
+
   proxmoxOstypesMap: [
     { value: 'debian', label: 'Debian' },
     { value: 'ubuntu', label: 'Ubuntu' },

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
@@ -162,6 +162,29 @@ const ProxmoxContainerOptions = ({
         value={opts?.searchdomain?.value}
         onChange={handleChange}
       />
+      <InputField
+        name={opts?.cmode?.name}
+        label={__('Console mode')}
+        type="select"
+        options={ProxmoxComputeSelectors.proxmoxCmodesMap}
+        value={opts?.cmode?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.tty?.name}
+        label={__('TTY count')}
+        type="number"
+        value={opts?.tty?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.console?.name}
+        label={__('Attach console (/dev/console)')}
+        type="checkbox"
+        value={opts?.console?.value}
+        checked={String(opts?.console?.value) === '1'}
+        onChange={handleChange}
+      />
     </div>
   );
 };

--- a/webpack/components/__tests__/ProxmoxComputeSelectors.test.js
+++ b/webpack/components/__tests__/ProxmoxComputeSelectors.test.js
@@ -22,6 +22,14 @@ describe('ProxmoxComputeSelectors', () => {
     expect(values).not.toContain('');
   });
 
+  it('contains known container console modes', () => {
+    const values = ProxmoxComputeSelectors.proxmoxCmodesMap.map(v => v.value);
+
+    expect(values).toContain('tty');
+    expect(values).toContain('console');
+    expect(values).toContain('shell');
+  });
+
   it('builds HDD controllers map from cloudinit controllers plus virtio', () => {
     const cloudinitValues = ProxmoxComputeSelectors.proxmoxControllersCloudinitMap.map(
       v => v.value


### PR DESCRIPTION
## Summary

Fixes #519.

Proxmox LXC containers expose console-related options — `cmode` (tty/console/shell), `tty` (number of ttys) and `console` (attach `/dev/console`) — that the plugin did not surface. This fills in the previously-empty container **Advanced** section with these three fields, for both the React front-end and the legacy ERB partial.

## Changes

- `proxmox_compute_selectors_helper.rb` + React `ProxmoxComputeSelectors.js`: a `cmode` options map (tty/console/shell).
- React `ProxmoxContainerOptions.js` + ERB `container/_advanced.html.erb`: Console mode select, TTY count counter and Attach-console checkbox.

`cmode`, `tty` and `console` are already declared attributes on the fog-proxmox `ServerConfig`, so they pass through on create and round-trip on edit without any gem change.

## Tests

- `#console options`: `cmode` / `tty` / `console` pass through `parse_typed_vm`.
- the `cmode` selector map contains tty/console/shell (Jest).

---

_Investigated and drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
