### PR TITLE
Fixes #516 - Add LXC tags, protection and timezone

### DIFF
--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -128,13 +128,16 @@ module ProxmoxVMAttrsHelper
       nameserver: vms.config.nameserver,
       searchdomain: vms.config.searchdomain,
       hostname: vms.config.hostname,
+      tags: (vms.config.respond_to?(:tags) ? vms.config.tags : nil),
+      protection: (vms.config.respond_to?(:protection) ? vms.config.protection : nil),
+      timezone: (vms.config.respond_to?(:timezone) ? vms.config.timezone : nil),
       ostemplate_storage: vms.ostemplate_storage,
       ostemplate_file: vms.ostemplate_file,
       start_after_create: vms.start_after_create,
       templated: vms.templated,
       is_secure_boot: vms.config.secure_boot?,
     }
-    vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname, :is_secure_boot]
+    vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname, :is_secure_boot, :tags, :protection, :timezone]
     extra_attrs = ActiveSupport::HashWithIndifferentAccess.new
     attributes.each do |key, value|
       camel_key = key.to_s.include?('_') ? snake_to_camel(key.to_s).to_sym : key

--- a/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
@@ -43,6 +43,9 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <%= text_f f, :hostname, :label => _('Hostname'), :label_size => "col-md-2", :disabled => true %>
   <%= text_f f, :nameserver, :label => _('DNS server'), :label_size => "col-md-2" %>
   <%= text_f f, :searchdomain, :label => _('Search domain'), :label_size => "col-md-2" %>
+  <%= text_f f, :timezone, :label => _('Time zone'), :label_size => "col-md-2", :help_inline => _('e.g. Europe/Prague or host') %>
+  <%= text_f f, :tags, :label => _('Tags'), :label_size => "col-md-2", :help_inline => _('Semicolon-separated, e.g. web;prod') %>
+  <%= checkbox_f f, :protection, :label => _('Protection') %>
   </div>
 <% end %>
 <%= field_set_tag _("Operating System"), :id => "container_config_os", :class => 'accordion-section', :disabled => !container do %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -161,6 +161,16 @@ module ForemanFogProxmox
         assert_equal expected_vm, vm
       end
 
+      test '#tags, protection and timezone pass through to the config' do
+        form = host_form.deep_merge(
+          'config_attributes' => { 'tags' => 'web;prod', 'protection' => '1', 'timezone' => 'Europe/Prague' }
+        )
+        vm = parse_typed_vm(form, type)
+        assert_equal 'web;prod', vm[:tags]
+        assert_equal '1', vm[:protection]
+        assert_equal 'Europe/Prague', vm[:timezone]
+      end
+
       test '#volume with rootfs 1Gb' do
         volumes = parse_typed_volumes(host_form['volumes_attributes'], type)
         assert_not volumes.empty?

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
@@ -162,6 +162,33 @@ const ProxmoxContainerOptions = ({
         value={opts?.searchdomain?.value}
         onChange={handleChange}
       />
+      <InputField
+        name={opts?.timezone?.name}
+        label={__('Time zone')}
+        info={__(
+          'Container time zone, e.g. Europe/Prague or "host" to use the host setting.'
+        )}
+        value={opts?.timezone?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.tags?.name}
+        label={__('Tags')}
+        info={__('Semicolon-separated list of tags, e.g. web;prod.')}
+        value={opts?.tags?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.protection?.name}
+        label={__('Protection')}
+        info={__(
+          'Prevent the container from being removed or its disks deleted.'
+        )}
+        type="checkbox"
+        value={opts?.protection?.value}
+        checked={String(opts?.protection?.value) === '1'}
+        onChange={handleChange}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #516.

Adds container **tags**, **protection** and **time zone** to the LXC options form (React front-end and the legacy ERB partial):

- `tags` — semicolon-separated tag list.
- `protection` — prevents the container being removed or its disks deleted.
- `timezone` — container time zone (e.g. `Europe/Prague`, or `host` to inherit the node setting).

These are plain Proxmox config keys, so they are passed straight through on create/update. The fields are surfaced through `additional_attrs` (guarded with `respond_to?`) so the new-container form works today.

## Dependency

Read round-trip — pre-filling the fields when editing an existing container — requires the attributes to be declared on fog-proxmox's `ServerConfig`: fog/fog-proxmox#139. Until that lands in a released gem the write path works and the fields render; the `respond_to?` guards keep the form working against the current released `fog-proxmox` (>= 0.16).

## Tests

- `#tags, protection and timezone pass through to the config`.

---

_Investigated and drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
