### PR TITLE
Fixes #513 - Add LXC container features (nesting, keyctl, fuse, mount)

### DIFF
--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -128,13 +128,18 @@ module ProxmoxVMAttrsHelper
       nameserver: vms.config.nameserver,
       searchdomain: vms.config.searchdomain,
       hostname: vms.config.hostname,
+      feature_nesting: vms.config.feature_nesting,
+      feature_keyctl: vms.config.feature_keyctl,
+      feature_fuse: vms.config.feature_fuse,
+      feature_mount: vms.config.feature_mount,
       ostemplate_storage: vms.ostemplate_storage,
       ostemplate_file: vms.ostemplate_file,
       start_after_create: vms.start_after_create,
       templated: vms.templated,
       is_secure_boot: vms.config.secure_boot?,
     }
-    vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname, :is_secure_boot]
+    vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname,
+                :is_secure_boot, :feature_nesting, :feature_keyctl, :feature_fuse, :feature_mount]
     extra_attrs = ActiveSupport::HashWithIndifferentAccess.new
     attributes.each do |key, value|
       camel_key = key.to_s.include?('_') ? snake_to_camel(key.to_s).to_sym : key

--- a/app/helpers/proxmox_vm_config_helper.rb
+++ b/app/helpers/proxmox_vm_config_helper.rb
@@ -115,14 +115,33 @@ module ProxmoxVMConfigHelper
     logger.debug("parsed_typed_config(#{type}): config_cpu=#{config_cpu}")
     cpu = parse_typed_cpu(config_cpu, type)
     memory = parse_typed_memory(config.select { |key, _value| config_typed_keys(type)[:memory].include? key }, type)
+    features = parse_typed_features(config)
     parsed_config = config.reject do |key, value|
-      config_a(type).include?(key) || ForemanFogProxmox::Value.empty?(value)
+      config_a(type).include?(key) || features_keys.include?(key) || ForemanFogProxmox::Value.empty?(value)
     end
     parsed_vm = args.reject { |key, value| args_a(type).include?(key) || ForemanFogProxmox::Value.empty?(value) }
     parsed_vm = parsed_vm.merge(config_options(config, args, type))
-    parsed_vm = parsed_vm.merge(parsed_config).merge(cpu).merge(memory)
+    parsed_vm = parsed_vm.merge(parsed_config).merge(cpu).merge(memory).merge(features)
     logger.debug("parsed_typed_config(#{type}): parsed_vm=#{parsed_vm}")
     parsed_vm
+  end
+
+  def features_keys
+    ['feature_nesting', 'feature_keyctl', 'feature_fuse', 'feature_mount']
+  end
+
+  # Serialise the individual container-feature form fields into a single
+  # Proxmox 'features' config value (e.g. 'nesting=1,keyctl=1,mount=nfs').
+  # When no toggle is set this returns {} so a fresh create sends nothing.
+  # On edit, disabling the last remaining feature is handled by
+  # reconcile_container_features, which needs the container's previous value.
+  def parse_typed_features(config)
+    parts = []
+    parts << 'nesting=1' if config['feature_nesting'] == '1'
+    parts << 'keyctl=1' if config['feature_keyctl'] == '1'
+    parts << 'fuse=1' if config['feature_fuse'] == '1'
+    parts << "mount=#{config['feature_mount']}" unless ForemanFogProxmox::Value.empty?(config['feature_mount'])
+    parts.empty? ? {} : { features: parts.join(',') }
   end
 
   def parse_typed_memory(args, type)

--- a/app/helpers/proxmox_vm_helper.rb
+++ b/app/helpers/proxmox_vm_helper.rb
@@ -58,4 +58,63 @@ module ProxmoxVMHelper
     logger.debug("parse_typed_vm(#{type}): parsed_vm=#{parsed_vm}")
     parsed_vm
   end
+
+  # The four container-feature form toggles own these Proxmox 'features'
+  # sub-flags. Any other sub-flag (e.g. mknod, force_rw_sys) can be set
+  # out-of-band and must be preserved when the value is rebuilt on edit.
+  def feature_toggle_keys
+    ['nesting', 'keyctl', 'fuse', 'mount']
+  end
+
+  # Reconcile the LXC 'features' config value on an update (edit path only).
+  #
+  # parse_typed_features rebuilds 'features' from the four form toggles, so:
+  #   * disabling the last remaining feature would otherwise omit the key
+  #     entirely and PVE would keep the old value (the disable is lost), and
+  #   * sub-flags set out-of-band (mknod, force_rw_sys, ...) would be dropped.
+  #
+  # This merges the toggle values over the container's current 'features'
+  # value, keeping unknown sub-flags. When the reconciled value is empty and
+  # the container previously had features, the key is explicitly unset through
+  # the Proxmox 'delete' mechanism (the same channel used to remove
+  # interfaces) rather than omitted. Fresh creates never reach here, so an
+  # empty features is never forced on create.
+  def reconcile_container_features(vmobj, config_attributes)
+    return unless vmobj.config.respond_to?(:features)
+
+    original = features_string_to_hash(vmobj.config.features)
+    return if original.empty? && !config_attributes.key?(:features)
+
+    preserved = original.reject { |key, _value| feature_toggle_keys.include?(key) }
+    selected = features_string_to_hash(config_attributes[:features])
+    merged = selected.merge(preserved)
+
+    config_attributes.delete(:features)
+    if merged.empty?
+      add_delete_key(config_attributes, 'features') unless original.empty?
+    else
+      config_attributes[:features] = features_hash_to_string(merged)
+    end
+  end
+
+  # Append a key to the comma-separated Proxmox 'delete' list without dropping
+  # any keys already queued for deletion (e.g. removed interfaces).
+  def add_delete_key(config_attributes, key)
+    keys = config_attributes[:delete].to_s.split(',').reject(&:empty?)
+    keys << key unless keys.include?(key)
+    config_attributes[:delete] = keys.join(',')
+  end
+
+  def features_string_to_hash(features)
+    return {} if ForemanFogProxmox::Value.empty?(features)
+
+    features.to_s.split(',').each_with_object({}) do |part, hash|
+      key, value = part.split('=', 2)
+      hash[key] = value
+    end
+  end
+
+  def features_hash_to_string(hash)
+    hash.map { |key, value| "#{key}=#{value}" }.join(',')
+  end
 end

--- a/app/models/concerns/fog_extensions/proxmox/server_config.rb
+++ b/app/models/concerns/fog_extensions/proxmox/server_config.rb
@@ -53,6 +53,37 @@ module FogExtensions
         secure_boot = bios == 'ovmf' && Foreman::Cast.to_bool(efidisk&.pre_enrolled_keys)
         Foreman::Cast.to_bool(secure_boot) ? '1' : '0'
       end
+
+      def feature_nesting
+        features_options['nesting']
+      end
+
+      def feature_keyctl
+        features_options['keyctl']
+      end
+
+      def feature_fuse
+        features_options['fuse']
+      end
+
+      def feature_mount
+        features_options['mount']
+      end
+
+      private
+
+      # Parse the Proxmox 'features' string (e.g. 'nesting=1,keyctl=1,mount=nfs')
+      # into a hash so the individual feature fields round-trip on read. Guarded
+      # with respond_to? so it also works against fog-proxmox versions that do
+      # not yet declare the 'features' attribute.
+      def features_options
+        return {} unless respond_to?(:features) && features
+
+        features.to_s.split(',').each_with_object({}) do |part, options|
+          key, value = part.split('=', 2)
+          options[key] = value
+        end
+      end
     end
   end
 end

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -126,6 +126,7 @@ module ForemanFogProxmox
 
         process_efidisk_removal(vm, processed_attributes)
 
+        reconcile_container_features(vm, config_attributes[:config_attributes])
         vm.update(config_attributes[:config_attributes])
         poolid = new_attributes['pool'] if new_attributes.key?('pool')
         update_pool(vm, poolid) if poolid

--- a/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
@@ -22,6 +22,10 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <div class="accordion-content">
   <%= textarea_f f, :description, :label => _('Description'), :label_size => "col-md-2" %>
   <%= checkbox_f f, :onboot, :label => _('Start at boot') %>
+  <%= checkbox_f f, :feature_nesting, :label => _('Feature: nesting') %>
+  <%= checkbox_f f, :feature_keyctl, :label => _('Feature: keyctl') %>
+  <%= checkbox_f f, :feature_fuse, :label => _('Feature: FUSE') %>
+  <%= text_f f, :feature_mount, :label => _('Feature: mount'), :label_size => "col-md-2", :help_inline => _('Semicolon-separated, e.g. nfs;cifs') %>
   </div>
 <% end %>
 <%= field_set_tag _("CPU"), :id => "container_config_cpu", :class => 'accordion-section', :disabled => !container do %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -161,6 +161,80 @@ module ForemanFogProxmox
         assert_equal expected_vm, vm
       end
 
+      test '#features serialises nesting, keyctl, fuse and mount' do
+        features = parse_typed_features(
+          'feature_nesting' => '1', 'feature_keyctl' => '1', 'feature_fuse' => '0', 'feature_mount' => 'nfs;cifs'
+        )
+        assert_equal 'nesting=1,keyctl=1,mount=nfs;cifs', features[:features]
+      end
+
+      test '#features omits unset flags' do
+        features = parse_typed_features('feature_nesting' => '1', 'feature_keyctl' => '0', 'feature_fuse' => '0', 'feature_mount' => '')
+        assert_equal 'nesting=1', features[:features]
+      end
+
+      test '#features empty when nothing enabled' do
+        features = parse_typed_features('feature_nesting' => '0', 'feature_keyctl' => '0', 'feature_fuse' => '0', 'feature_mount' => '')
+        assert_empty features
+      end
+
+      def mock_container(features_value)
+        config = mock('config')
+        config.stubs(:features).returns(features_value)
+        vm = mock('vm')
+        vm.stubs(:config).returns(config)
+        vm
+      end
+
+      test '#reconcile clears last feature on edit through the delete list' do
+        # container had features=nesting=1, user unchecked every toggle
+        vm = mock_container('nesting=1')
+        config_attributes = ActiveSupport::HashWithIndifferentAccess.new
+        reconcile_container_features(vm, config_attributes)
+        assert_equal 'features', config_attributes[:delete]
+        assert_not config_attributes.key?(:features)
+      end
+
+      test '#reconcile keeps setting features on edit' do
+        vm = mock_container('nesting=1')
+        config_attributes = ActiveSupport::HashWithIndifferentAccess.new(features: 'nesting=1,keyctl=1')
+        reconcile_container_features(vm, config_attributes)
+        assert_equal 'nesting=1,keyctl=1', config_attributes[:features]
+        assert_not config_attributes.key?(:delete)
+      end
+
+      test '#reconcile preserves unknown sub-flags set out-of-band' do
+        # nesting disabled, keyctl enabled, mknod was set out-of-band
+        vm = mock_container('nesting=1,mknod=1')
+        config_attributes = ActiveSupport::HashWithIndifferentAccess.new(features: 'keyctl=1')
+        reconcile_container_features(vm, config_attributes)
+        assert_equal 'keyctl=1,mknod=1', config_attributes[:features]
+        assert_not config_attributes.key?(:delete)
+      end
+
+      test '#reconcile keeps unknown sub-flags when all toggles are cleared' do
+        vm = mock_container('nesting=1,mknod=1')
+        config_attributes = ActiveSupport::HashWithIndifferentAccess.new
+        reconcile_container_features(vm, config_attributes)
+        assert_equal 'mknod=1', config_attributes[:features]
+        assert_not config_attributes.key?(:delete)
+      end
+
+      test '#reconcile does not clear features when there was no prior value' do
+        vm = mock_container('')
+        config_attributes = ActiveSupport::HashWithIndifferentAccess.new
+        reconcile_container_features(vm, config_attributes)
+        assert_not config_attributes.key?(:delete)
+        assert_not config_attributes.key?(:features)
+      end
+
+      test '#reconcile appends features to an existing delete list' do
+        vm = mock_container('nesting=1')
+        config_attributes = ActiveSupport::HashWithIndifferentAccess.new(delete: 'net0')
+        reconcile_container_features(vm, config_attributes)
+        assert_equal 'net0,features', config_attributes[:delete]
+      end
+
       test '#volume with rootfs 1Gb' do
         volumes = parse_typed_volumes(host_form['volumes_attributes'], type)
         assert_not volumes.empty?

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_commands_container_test.rb
@@ -249,6 +249,37 @@ module ForemanFogProxmox
         vm.expects(:update, expected_config_attr)
         @cr.save_vm(uuid, new_attributes)
       end
+
+      it 'clears container features when the last feature is unchecked on edit' do
+        uuid = '100'
+        config = mock('config')
+        config.stubs(:attributes).returns(:cores => '')
+        config.stubs(:efidisk).returns(nil)
+        config.stubs(:features).returns('nesting=1')
+        vm = mock('vm')
+        vm.stubs(:config).returns(config)
+        vm.stubs(:container?).returns(true)
+        vm.stubs(:type).returns('lxc')
+        vm.stubs(:node_id).returns('proxmox')
+        vm.stubs(:attributes).returns(node_id: 'proxmox', type: 'lxc')
+        @cr.stubs(:find_vm_by_uuid).returns(vm)
+        new_attributes = {
+          'templated' => '0',
+          'node_id' => 'proxmox',
+          'config_attributes' => {
+            'cores' => '1',
+            'cpulimit' => '1',
+            'feature_nesting' => '0',
+            'feature_keyctl' => '0',
+            'feature_fuse' => '0',
+            'feature_mount' => '',
+          },
+        }.with_indifferent_access
+        # An edit that unchecks the last feature must unset it via the Proxmox
+        # 'delete' list, not omit the key (which would keep the old value).
+        vm.expects(:update).with { |attrs| attrs[:delete] == 'features' && !attrs.key?(:features) }
+        @cr.save_vm(uuid, new_attributes)
+      end
     end
 
     describe 'create_vm' do

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
@@ -162,6 +162,46 @@ const ProxmoxContainerOptions = ({
         value={opts?.searchdomain?.value}
         onChange={handleChange}
       />
+      <InputField
+        name={opts?.featureNesting?.name}
+        label={__('Feature: nesting')}
+        info={__(
+          'Allow nested virtualization / running containers inside the container.'
+        )}
+        type="checkbox"
+        value={opts?.featureNesting?.value}
+        checked={String(opts?.featureNesting?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.featureKeyctl?.name}
+        label={__('Feature: keyctl')}
+        info={__(
+          'Enable the keyctl() system call (needed by some workloads, e.g. systemd).'
+        )}
+        type="checkbox"
+        value={opts?.featureKeyctl?.value}
+        checked={String(opts?.featureKeyctl?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.featureFuse?.name}
+        label={__('Feature: FUSE')}
+        info={__('Allow using FUSE file systems inside the container.')}
+        type="checkbox"
+        value={opts?.featureFuse?.value}
+        checked={String(opts?.featureFuse?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.featureMount?.name}
+        label={__('Feature: mount')}
+        info={__(
+          'Semicolon-separated list of file systems allowed to be mounted, e.g. nfs;cifs.'
+        )}
+        value={opts?.featureMount?.value}
+        onChange={handleChange}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #513.

Adds LXC container **features** to the options form (React front-end and the legacy ERB partial): nesting, keyctl, FUSE and the mount file-system list. The individual fields are serialised into Proxmox's single `features` config value (e.g. `nesting=1,keyctl=1,mount=nfs;cifs`) on create/update, and parsed back on read.

- `nesting`, `keyctl`, `fuse` — checkboxes.
- `mount` — semicolon-separated list of file systems allowed to be mounted.

## Dependency

Read round-trip (pre-filling the feature fields when editing an existing container) reads fog-proxmox's `features` attribute, declared in fog/fog-proxmox#139. `FogExtensions::Proxmox::ServerConfig#features_options` is guarded with `respond_to?(:features)`, so the form keeps working against the current released `fog-proxmox` (>= 0.16); full round-trip lands once #139 is released. Write / serialisation works today.

## Tests

- `#features serialises nesting, keyctl, fuse and mount`.
- unset flags are omitted.
- empty when nothing is enabled.

---

_Investigated and drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
