### PR TITLE
Fixes #517 - Complete LXC mount-point options and add bind mounts

### DIFF
--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -25,6 +25,10 @@ require 'foreman_fog_proxmox/hash_collection'
 
 # Convert a foreman form server hash into a fog-proxmox server attributes hash
 module ProxmoxVMAttrsHelper
+  # Mount-point options that only round-trip on read once fog-proxmox declares
+  # them (see fog/fog-proxmox#137); surfaced conditionally via respond_to?.
+  MOUNT_POINT_FOG_OPTION_KEYS = %w[ro mountoptions acl quota].freeze
+
   def object_to_attributes_hash(vms, from_profile, start_checked)
     param_scope = from_profile ? "compute_attribute[vm_attrs]" : "host[compute_attributes]"
     vm_h = ActiveSupport::HashWithIndifferentAccess.new
@@ -82,7 +86,8 @@ module ProxmoxVMAttrsHelper
         keys = ['id', 'volid', 'storage_type', 'storage', 'controller', 'device']
         type = 'cloud_init'
       elsif vol.mount_point?
-        keys = ['id', 'volid', 'storage_type', 'storage', 'device', 'mp', 'size', 'backup']
+        keys = ['id', 'volid', 'storage_type', 'storage', 'device', 'mp', 'size', 'backup', 'replicate', 'shared']
+        keys += MOUNT_POINT_FOG_OPTION_KEYS.select { |key| vol.respond_to?(key) }
         type = 'mount_point'
       end
       vol_attrs << { :name => type, :value => vol_keys(param_scope, keys, vol, id) }

--- a/app/helpers/proxmox_vm_volumes_helper.rb
+++ b/app/helpers/proxmox_vm_volumes_helper.rb
@@ -27,10 +27,17 @@ module ProxmoxVMVolumesHelper
   include ProxmoxVMCdromHelper
   include ProxmoxVMCloudinitHelper
 
-  def add_disk_options(disk, args)
+  def add_disk_options(disk, args, bind_mount: false)
     options = ForemanFogProxmox::HashCollection.new_hash_reject_keys(args,
       ['id', 'volid', 'controller', 'device', 'storage', 'size', '_delete', 'storage_type'])
     ForemanFogProxmox::HashCollection.remove_empty_values(options)
+    # backup/quota/replicate/shared only apply to storage-backed volumes; PVE
+    # rejects them on bind mounts, so drop them there.
+    options.reject! { |key, _value| ['backup', 'quota', 'replicate', 'shared'].include?(key.to_s) } if bind_mount
+    # Drop boolean options left at their PVE default so they are not written out
+    # on every volume: ro/acl/quota/shared default to 0, replicate defaults to 1.
+    options.reject! { |key, value| ['ro', 'acl', 'quota', 'shared'].include?(key.to_s) && value.to_s == '0' }
+    options.reject! { |key, value| key.to_s == 'replicate' && value.to_s == '1' }
     disk[:options] = options
   end
 
@@ -53,22 +60,29 @@ module ProxmoxVMVolumesHelper
     disk = {}
     rootfs_volume = rootfs_volume?(args)
     set_disk_attributes(disk, args)
-    if rootfs_volume
+    # A bind mount references an absolute host path as its volume; like rootfs it
+    # is not a storage-backed volume, so PVE does not accept a backup flag on it.
+    bind_mount = disk[:volid].to_s.start_with?('/')
+    if rootfs_volume || bind_mount
       args.delete('backup')
     elsif args['backup'].nil?
       args['backup'] = '1'
     end
     if args.key?('options')
       options = args['options']
-      if rootfs_volume && options.respond_to?(:delete)
+      if (rootfs_volume || bind_mount) && options.respond_to?(:delete)
         options = options.dup
         options.delete('backup')
       end
       disk[:options] = options
     else
-      add_disk_options(disk, args)
+      add_disk_options(disk, args, bind_mount: bind_mount)
     end
-    disk.key?(:storage) ? disk : {}
+    # A bind mount references an absolute host path as its volume, so it has a
+    # volid but no storage; accept it as well as regular storage-backed disks.
+    return disk if disk.key?(:storage) || disk.key?(:volid)
+
+    {}
   end
 
   def rootfs_volume?(args)
@@ -79,7 +93,9 @@ module ProxmoxVMVolumesHelper
     disk[:id] = args['id'] if args.key?('id')
     disk[:volid] = args['volid'] if args.key?('volid') && !args['volid'].empty?
     disk[:storage] = args['storage'].to_s if args.key?('storage') && !args['storage'].empty?
-    disk[:size] = args['size'].to_i if args.key?('size') && !args['size'].empty?
+    # A bind mount (host-path volid) has no size, so only set it otherwise.
+    bind_mount = disk[:volid].to_s.start_with?('/')
+    disk[:size] = args['size'].to_i if args.key?('size') && !args['size'].empty? && !bind_mount
   end
 
   def volume_type?(args, type)

--- a/app/views/compute_resources_vms/form/proxmox/container/_volume_mp.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_volume_mp.html.erb
@@ -24,4 +24,11 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
     <%= text_f f, :mp, :label => _('Path'), :label_size => "col-md-2", :required => true, :help_inline => _("e.g. /path/to/") %>
     <%= text_f f, :device, :label => _('Device'), :label_size => "col-md-2", :class => ('hide' if f.object.rootfs?), :disabled => (!new_volume || f.object.rootfs?), :'data-soft-max' => 10 %>
     <%= text_f f, :size, :class => "input-mini", :label => _("Size (GB)"), :label_size => "col-md-2" %>
+    <%= text_f f, :volid, :label => _('Host path (bind mount)'), :label_size => "col-md-2", :help_inline => _('e.g. /host/dir; leave storage empty for a bind mount') %>
+    <%= checkbox_f f, :ro, :label => _('Read-only') %>
+    <%= checkbox_f f, :acl, :label => _('ACL') %>
+    <%= checkbox_f f, :quota, :label => _('Quota') %>
+    <%= checkbox_f f, :replicate, :label => _('Replicate') %>
+    <%= checkbox_f f, :shared, :label => _('Shared') %>
+    <%= text_f f, :mountoptions, :label => _('Mount options'), :label_size => "col-md-2", :help_inline => _('Semicolon-separated, e.g. noatime;nodev') %>
 <% end %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -173,6 +173,36 @@ module ForemanFogProxmox
         assert_equal 'local-lvm:1,mp=/opt/path,backup=1', mp0[:mp0]
       end
 
+      test '#mount point serialises ro, quota and mountoptions and drops disabled booleans' do
+        args = { 'id' => 'mp0', 'storage' => 'local-lvm', 'size' => '8', 'mp' => '/data',
+                 'backup' => '1', 'ro' => '1', 'acl' => '0', 'quota' => '1', 'replicate' => '0',
+                 'shared' => '0', 'mountoptions' => 'noatime;nodev' }
+        volume = parse_typed_volume(args, type)
+        assert volume.key?(:mp0)
+        value = volume[:mp0]
+        assert_includes value, 'local-lvm:8'
+        assert_includes value, 'mp=/data'
+        assert_includes value, 'ro=1'
+        assert_includes value, 'quota=1'
+        assert_includes value, 'mountoptions=noatime;nodev'
+        assert_not_includes value, 'acl=0'
+        assert_not_includes value, 'shared=0'
+        # replicate defaults to 1 in PVE, so an explicit 0 must be sent to disable it
+        assert_includes value, 'replicate=0'
+      end
+
+      test '#bind mount uses the host path as the volume without storage, size or backup' do
+        args = { 'id' => 'mp1', 'storage' => '', 'size' => '8', 'mp' => '/data', 'volid' => '/host/dir', 'backup' => '1' }
+        volume = parse_typed_volume(args, type)
+        assert volume.key?(:mp1)
+        value = volume[:mp1]
+        assert value.start_with?('/host/dir')
+        assert_includes value, 'mp=/data'
+        assert_not_includes value, 'size='
+        # backup only applies to storage-backed volumes, not bind mounts
+        assert_not_includes value, 'backup'
+      end
+
       test '#interface with name eth0 and bridge' do
         deletes = []
         nics = []

--- a/webpack/components/ProxmoxContainer/MountPoint.js
+++ b/webpack/components/ProxmoxContainer/MountPoint.js
@@ -10,7 +10,11 @@ const MountPoint = ({ id, data, storagesMap }) => {
   const [error, setError] = useState('');
 
   const handleChange = e => {
-    const { name, value } = e.target;
+    const { name, type, checked, value: targetValue } = e.target;
+    let value = targetValue;
+    if (type === 'checkbox') {
+      value = checked ? '1' : '0';
+    }
     const updatedKey = Object.keys(mp).find(key => mp[key].name === name);
     const updatedData = {
       ...mp,
@@ -68,16 +72,66 @@ const MountPoint = ({ id, data, storagesMap }) => {
         options={ProxmoxComputeSelectors.proxmoxBackupsMap}
         onChange={handleChange}
       />
+      <InputField
+        name={mp?.volid?.name}
+        label={__('Host path (bind mount)')}
+        info={__(
+          'Optional. Set an absolute host directory (e.g. /host/dir) to create a bind mount instead of a storage-backed volume; leave the storage empty in that case.'
+        )}
+        value={mp?.volid?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={mp?.ro?.name}
+        label={__('Read-only')}
+        type="checkbox"
+        value={mp?.ro?.value}
+        checked={String(mp?.ro?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={mp?.acl?.name}
+        label={__('ACL')}
+        type="checkbox"
+        value={mp?.acl?.value}
+        checked={String(mp?.acl?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={mp?.quota?.name}
+        label={__('Quota')}
+        type="checkbox"
+        value={mp?.quota?.value}
+        checked={String(mp?.quota?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={mp?.replicate?.name}
+        label={__('Replicate')}
+        type="checkbox"
+        value={mp?.replicate?.value}
+        checked={String(mp?.replicate?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={mp?.shared?.name}
+        label={__('Shared')}
+        type="checkbox"
+        value={mp?.shared?.value}
+        checked={String(mp?.shared?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={mp?.mountoptions?.name}
+        label={__('Mount options')}
+        info={__('Semicolon-separated fs mount options, e.g. noatime;nodev.')}
+        value={mp?.mountoptions?.value}
+        onChange={handleChange}
+      />
       <input
         name={mp?.id?.name}
         type="hidden"
         value={mp?.id?.value}
-        onChange={handleChange}
-      />
-      <input
-        name={mp?.volid?.name}
-        type="hidden"
-        value={mp?.volid?.value}
         onChange={handleChange}
       />
     </div>

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerStorage.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerStorage.js
@@ -106,6 +106,30 @@ const ProxmoxContainerStorage = ({
           name: `${paramScope}[volumes_attributes][${nextId}][backup]`,
           value: '1',
         },
+        ro: {
+          name: `${paramScope}[volumes_attributes][${nextId}][ro]`,
+          value: '0',
+        },
+        acl: {
+          name: `${paramScope}[volumes_attributes][${nextId}][acl]`,
+          value: '0',
+        },
+        quota: {
+          name: `${paramScope}[volumes_attributes][${nextId}][quota]`,
+          value: '0',
+        },
+        replicate: {
+          name: `${paramScope}[volumes_attributes][${nextId}][replicate]`,
+          value: '1',
+        },
+        shared: {
+          name: `${paramScope}[volumes_attributes][${nextId}][shared]`,
+          value: '0',
+        },
+        mountoptions: {
+          name: `${paramScope}[volumes_attributes][${nextId}][mountoptions]`,
+          value: '',
+        },
         volid: {
           name: `${paramScope}[volumes_attributes][${nextId}][volid]`,
           value: '',


### PR DESCRIPTION
## Summary

Fixes #517.

Completes LXC mount-point support in the container storage form (React front-end and the legacy ERB partial):

- **Options**: read-only (`ro`), `acl`, `quota`, `replicate`, `shared` (checkboxes) and `mountoptions` (semicolon-separated). These flow through to the `mpN` config string; disabled boolean options are dropped rather than written as `ro=0`, `acl=0`, etc.
- **Bind mounts**: an optional *Host path* field. Setting an absolute host directory (e.g. `/host/dir`) with an empty storage creates a bind mount — the host path becomes the volume, with no storage and no size. `parse_hard_disk_volume` now accepts a volume that has a host-path volid but no storage, and `set_disk_attributes` skips the size for it.

## Dependency

Read round-trip of `ro`, `mountoptions`, `acl` and `quota` (pre-filling them when editing an existing container) reads the corresponding fog-proxmox `Disk` attributes added in fog/fog-proxmox#137; they are surfaced conditionally via `respond_to?`, so the form works against the current released `fog-proxmox` (>= 0.16) and rounds these four out once #137 releases. `replicate`, `shared`, bind mounts and the whole write path work today (`replicate`/`shared` are already declared in the released gem).

## Tests

- `#mount point serialises ro, quota and mountoptions and drops disabled booleans`.
- `#bind mount uses the host path as the volume without storage or size`.

---

_Investigated and drafted with the assistance of Claude (Cowork); reviewed by me before submitting._



---

**Behavior change:** the mount-point *Replicate* option now defaults to enabled (`replicate=1`, the PVE default) and the plugin sends an explicit `replicate=0` when it is unchecked, so storage replication can actually be turned off from the form (previously `replicate=0` was dropped and PVE kept replication on). Volume-only options (`backup`, `quota`, `replicate`, `shared`) are also stripped for bind mounts, which PVE rejects on them.
