### PR TITLE
Fixes #520 - Add HA placement of guests at provisioning time

### DIFF
--- a/app/helpers/proxmox_compute_selectors_helper.rb
+++ b/app/helpers/proxmox_compute_selectors_helper.rb
@@ -28,6 +28,13 @@ module ProxmoxComputeSelectorsHelper
      OpenStruct.new(id: 'i386', name: '32 bits')]
   end
 
+  def proxmox_ha_states_map
+    [OpenStruct.new(id: 'started', name: 'started'),
+     OpenStruct.new(id: 'stopped', name: 'stopped'),
+     OpenStruct.new(id: 'ignored', name: 'ignored'),
+     OpenStruct.new(id: 'disabled', name: 'disabled')]
+  end
+
   def proxmox_ostypes_map
     [OpenStruct.new(id: 'debian', name: 'Debian'),
      OpenStruct.new(id: 'ubuntu', name: 'Ubuntu'),

--- a/app/helpers/proxmox_vm_attrs_helper.rb
+++ b/app/helpers/proxmox_vm_attrs_helper.rb
@@ -133,6 +133,9 @@ module ProxmoxVMAttrsHelper
       start_after_create: vms.start_after_create,
       templated: vms.templated,
       is_secure_boot: vms.config.secure_boot?,
+      ha_managed: (vms.respond_to?(:ha) ? vms.ha&.dig('managed') : nil),
+      ha_group: (vms.respond_to?(:ha) ? vms.ha&.dig('group') : nil),
+      ha_state: (vms.respond_to?(:ha) ? vms.ha&.dig('state') : nil),
     }
     vms_keys = [:cpu_type, :nameserver, :searchdomain, :hostname, :is_secure_boot]
     extra_attrs = ActiveSupport::HashWithIndifferentAccess.new

--- a/app/helpers/proxmox_vm_config_helper.rb
+++ b/app/helpers/proxmox_vm_config_helper.rb
@@ -42,6 +42,7 @@ module ProxmoxVMConfigHelper
   def general_a(type)
     general_a = ['node_id', 'type', 'config_attributes', 'efidisk_attributes', 'volumes_attributes', 'interfaces_attributes', 'image_id']
     general_a += ['firmware_type', 'provision_method', 'container_volumes', 'server_volumes', 'start_after_create']
+    general_a += ['ha_managed', 'ha_group', 'ha_state']
     general_a += ['name'] if type == 'lxc'
     general_a
   end

--- a/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_commands.rb
@@ -48,11 +48,30 @@ module ForemanFogProxmox
         logger.warn("create vm: args=#{args}")
         vm = node.send(vm_collection(type)).create(parse_typed_vm(args, type))
       end
+      register_ha_resource(vm, args)
       start_on_boot(vm, args)
     rescue StandardError => e
       logger.warn("failed to create vm: #{e}")
       destroy_vm id.to_s + '_' + vm.vmid.to_s if vm
       raise e
+    end
+
+    # Optionally place the freshly created guest under the cluster HA manager.
+    # Requires a fog-proxmox that exposes the ha_resources collection
+    # (see fog/fog-proxmox#138); silently skipped otherwise.
+    def register_ha_resource(vm, args)
+      return unless Foreman::Cast.to_bool(args[:ha_managed])
+      unless client.respond_to?(:ha_resources)
+        logger.warn("HA placement was requested for #{vm.vmid} but the installed fog-proxmox does not expose HA resources (needs the release including fog/fog-proxmox#138); skipping HA registration")
+        return
+      end
+
+      attributes = { sid: "#{vm.container? ? 'ct' : 'vm'}:#{vm.vmid}" }
+      attributes[:group] = args[:ha_group] if args[:ha_group].present?
+      attributes[:state] = args[:ha_state] if args[:ha_state].present?
+      client.ha_resources.create(attributes)
+    rescue StandardError => e
+      logger.warn("failed to register HA resource for #{vm.vmid}: #{e}")
     end
 
     def assign_vmid(vmid, node, log: true)

--- a/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/container/_config.html.erb
@@ -22,6 +22,9 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
   <div class="accordion-content">
   <%= textarea_f f, :description, :label => _('Description'), :label_size => "col-md-2" %>
   <%= checkbox_f f, :onboot, :label => _('Start at boot') %>
+  <%= checkbox_f f, :ha_managed, :label => _('HA managed') %>
+  <%= text_f f, :ha_group, :label => _('HA group'), :label_size => "col-md-2" %>
+  <%= select_f f, :ha_state, proxmox_ha_states_map, :id, :name, { :include_blank => true }, :label => _('HA state'), :label_size => "col-md-2" %>
   </div>
 <% end %>
 <%= field_set_tag _("CPU"), :id => "container_config_cpu", :class => 'accordion-section', :disabled => !container do %>

--- a/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
+++ b/test/unit/foreman_fog_proxmox/helpers/proxmox_container_helper_test.rb
@@ -161,6 +161,15 @@ module ForemanFogProxmox
         assert_equal expected_vm, vm
       end
 
+      test '#HA provisioning attributes are not sent as guest config' do
+        form = host_form.merge('ha_managed' => '1', 'ha_group' => 'prod', 'ha_state' => 'started')
+        vm = parse_typed_vm(form, type)
+        assert_not vm.key?(:ha_managed)
+        assert_not vm.key?(:ha_group)
+        assert_not vm.key?(:ha_state)
+        assert_includes args_a(type), 'ha_managed'
+      end
+
       test '#volume with rootfs 1Gb' do
         volumes = parse_typed_volumes(host_form['volumes_attributes'], type)
         assert_not volumes.empty?

--- a/webpack/components/ProxmoxComputeSelectors.js
+++ b/webpack/components/ProxmoxComputeSelectors.js
@@ -24,6 +24,13 @@ const ProxmoxComputeSelectors = {
     { value: 'i386', label: '32 bits' },
   ],
 
+  proxmoxHaStatesMap: [
+    { value: 'started', label: 'started' },
+    { value: 'stopped', label: 'stopped' },
+    { value: 'ignored', label: 'ignored' },
+    { value: 'disabled', label: 'disabled' },
+  ],
+
   proxmoxOstypesMap: [
     { value: 'debian', label: 'Debian' },
     { value: 'ubuntu', label: 'Ubuntu' },

--- a/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
+++ b/webpack/components/ProxmoxContainer/ProxmoxContainerOptions.js
@@ -162,6 +162,31 @@ const ProxmoxContainerOptions = ({
         value={opts?.searchdomain?.value}
         onChange={handleChange}
       />
+      <InputField
+        name={opts?.haManaged?.name}
+        label={__('HA managed')}
+        info={__(
+          'Place this container under the cluster HA manager at creation.'
+        )}
+        type="checkbox"
+        value={opts?.haManaged?.value}
+        checked={String(opts?.haManaged?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.haGroup?.name}
+        label={__('HA group')}
+        value={opts?.haGroup?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.haState?.name}
+        label={__('HA state')}
+        type="select"
+        options={ProxmoxComputeSelectors.proxmoxHaStatesMap}
+        value={opts?.haState?.value}
+        onChange={handleChange}
+      />
     </div>
   );
 };

--- a/webpack/components/ProxmoxServer/ProxmoxServerOptions.js
+++ b/webpack/components/ProxmoxServer/ProxmoxServerOptions.js
@@ -115,6 +115,29 @@ const ProxmoxServerOptions = ({ options }) => {
         value={opts?.ostype?.value}
         onChange={handleChange}
       />
+      <InputField
+        name={opts?.haManaged?.name}
+        label={__('HA managed')}
+        info={__('Place this guest under the cluster HA manager at creation.')}
+        type="checkbox"
+        value={opts?.haManaged?.value}
+        checked={String(opts?.haManaged?.value) === '1'}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.haGroup?.name}
+        label={__('HA group')}
+        value={opts?.haGroup?.value}
+        onChange={handleChange}
+      />
+      <InputField
+        name={opts?.haState?.name}
+        label={__('HA state')}
+        type="select"
+        options={ProxmoxComputeSelectors.proxmoxHaStatesMap}
+        value={opts?.haState?.value}
+        onChange={handleChange}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #520.

Adds optional placement of a guest under the Proxmox cluster HA manager at provisioning time, for both servers (QEMU) and containers (LXC):

- Form: **HA managed** (checkbox), **HA group** and **HA state** (started/stopped/ignored/disabled) on the server and container option forms (React) and the container ERB partial.
- On create, after the guest is created it is registered as an HA resource (`<vm|ct>:<vmid>`) with the chosen group/state. The HA provisioning fields are stripped from the guest config so they are never sent to the VM/CT create call.

## Dependency

Registration uses fog-proxmox's `ha_resources` collection, added in fog/fog-proxmox#138. `ProxmoxVMCommands#register_ha_resource` is guarded with `client.respond_to?(:ha_resources)`, so provisioning is unaffected on the current released `fog-proxmox` (>= 0.16) — the fields render and are accepted, and HA registration activates once #138 is released.

## Tests

- `#HA provisioning attributes are not sent as guest config` — the `ha_*` params are stripped from the parsed guest attributes.

---

_Investigated and drafted with the assistance of Claude (Cowork); reviewed by me before submitting._
