### PR TITLE
Fix Proxmox network interface modal dropdown positioning

### DIFF
--- a/app/assets/javascripts/foreman_fog_proxmox/proxmox_network_interface_modal.js
+++ b/app/assets/javascripts/foreman_fog_proxmox/proxmox_network_interface_modal.js
@@ -1,0 +1,11 @@
+$(document)
+  .on('show.bs.modal', '#interfaceModal', function () {
+    var modal = $(this);
+    modal.toggleClass(
+      'proxmox-interface-modal',
+      modal.find('.proxmox-interface-form').length > 0
+    );
+  })
+  .on('hidden.bs.modal', '#interfaceModal', function () {
+    $(this).removeClass('proxmox-interface-modal');
+  });

--- a/app/assets/stylesheets/foreman_fog_proxmox/network_interface_modal.css
+++ b/app/assets/stylesheets/foreman_fog_proxmox/network_interface_modal.css
@@ -1,0 +1,17 @@
+#interfaceModal.proxmox-interface-modal {
+  overflow-y: hidden;
+}
+
+#interfaceModal.proxmox-interface-modal .modal-content {
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  overflow: hidden;
+}
+
+#interfaceModal.proxmox-interface-modal .modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}

--- a/app/views/compute_resources_vms/form/proxmox/_add_react_component_to_host_form.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_add_react_component_to_host_form.html.erb
@@ -1,4 +1,9 @@
+<% content_for(:stylesheets) do %>
+  <%= stylesheet_link_tag 'foreman_fog_proxmox/network_interface_modal' %>
+<% end %>
+
 <% content_for(:javascripts) do %>
+  <%= javascript_include_tag 'foreman_fog_proxmox/proxmox_network_interface_modal' %>
   <%= webpacked_plugins_js_for :foreman_fog_proxmox %>
 <% end %>
 <%= react_component('ProxmoxVmType', { registerComp: true }) unless @host.managed %>

--- a/app/views/compute_resources_vms/form/proxmox/_add_vm_type_to_nic_provider_specific_form.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_add_vm_type_to_nic_provider_specific_form.html.erb
@@ -20,12 +20,13 @@ along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
 <% vm_type = vm_type_and_node_id[:vm_type] %>
 <% node_id = vm_type_and_node_id[:node_id] %>
 
-<%= f.fields_for 'compute_attributes', OpenStruct.new(compute_attributes) do |f| %>
-    <%= render provider_partial(@host.compute_resource, 'network'), :f => f, :vm_type => vm_type, :node_id => node_id, :disabled => f.object.persisted?, :compute_resource => @host.compute_resource, :new_host => new_vm, :new_vm => new_vm %>
-<% end %>
+<div class="proxmox-interface-form">
+  <%= f.fields_for 'compute_attributes', OpenStruct.new(compute_attributes) do |f| %>
+      <%= render provider_partial(@host.compute_resource, 'network'), :f => f, :vm_type => vm_type, :node_id => node_id, :disabled => f.object.persisted?, :compute_resource => @host.compute_resource, :new_host => new_vm, :new_vm => new_vm %>
+  <% end %>
+</div>
 <% else %>
 <%= f.fields_for 'compute_attributes', OpenStruct.new(f.object.compute_attributes) do |f| %>
     <%= render provider_partial(@host.compute_resource, 'network'), :f => f, :disabled => f.object.persisted?, :compute_resource => @host.compute_resource, :new_host => new_vm, :new_vm => new_vm %>
 <% end %>
 <% end %>
-


### PR DESCRIPTION
The issue was Select2 calculates the dropdown position relative to its parent. When the interface modal is scrolled, the position is calculated incorrectly causing the dropdown to become detached from its field.

To solve this I moved scrolling from the modal to the modal body so the dropdown stays correctly aligned.