### PR TITLE
Fix duplicates reported by available_images()

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_images.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_images.rb
@@ -41,7 +41,7 @@ module ForemanFogProxmox
     end
 
     def available_images
-      templates.collect { |template| OpenStruct.new(id: template_uuid(template), name: template_name(template)) }
+      templates.collect { |template| OpenStruct.new(id: template_uuid(template), name: template_name(template)) }.uniq
     end
 
     def templates

--- a/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_images_test.rb
@@ -43,5 +43,18 @@ module ForemanFogProxmox
         @cr.clone_from_image(@image, @vmid)
       end
     end
+
+    describe 'available_images' do
+      it 'removes duplicates' do
+        @cr = FactoryBot.build_stubbed(:proxmox_cr)
+        clone = mock('vm')
+        clone.stubs(:name).returns('vm-1')
+        @cr.stubs(:find_vm_by_uuid).returns(clone)
+        template = mock('template')
+        template.stubs(:vmid).returns(100).at_least(2)
+        @cr.stubs(:templates).returns([template, template])
+        assert_equal 1, @cr.available_images.length
+      end
+    end
   end
 end


### PR DESCRIPTION
Having Templates with multiple disks resulted in every template being reported the number of disks by available_images.

Fixes #539