### PR TITLE
Fixes #368: Filter offline Proxmox nodes from VM forms

### DIFF
--- a/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
+++ b/app/controllers/foreman_fog_proxmox/compute_resources_controller.rb
@@ -95,20 +95,28 @@ module ForemanFogProxmox
     # GET foreman_fog_proxmox/metadata/:compute_resource_id
     def metadata
       cr = ComputeResource.find(params[:compute_resource_id])
+      node_availability = cr.node_availability
+      available_nodes = node_availability[:available]
+      default_node_id = available_nodes.first&.node
 
       render json: {
-        nodes: extract_nodes(cr),
+        nodes: extract_nodes(available_nodes),
+        offline_nodes: extract_node_names(node_availability[:offline]),
         pools: extract_pools(cr),
-        storages: extract_storages(cr),
-        bridges: extract_bridges(cr),
+        storages: default_node_id ? extract_storages(cr, default_node_id) : [],
+        bridges: default_node_id ? extract_bridges(cr, default_node_id) : [],
         images: extract_images(cr),
       }
     end
 
     private
 
-    def extract_nodes(compute_resource)
-      Array(compute_resource.nodes).map { |n| { node: n.node } }
+    def extract_nodes(nodes)
+      Array(nodes).map { |n| { node: n.node } }
+    end
+
+    def extract_node_names(nodes)
+      Array(nodes).map(&:node)
     end
 
     def extract_pools(compute_resource)
@@ -118,8 +126,8 @@ module ForemanFogProxmox
       end
     end
 
-    def extract_storages(compute_resource)
-      Array(compute_resource.storages).map do |s|
+    def extract_storages(compute_resource, node_id)
+      Array(compute_resource.storages(node_id)).map do |s|
         h = s.respond_to?(:as_json) ? s.as_json : s
         {
           storage: (h[:storage] || h['storage']),
@@ -132,8 +140,8 @@ module ForemanFogProxmox
       end
     end
 
-    def extract_bridges(compute_resource)
-      Array(compute_resource.bridges).map do |b|
+    def extract_bridges(compute_resource, node_id)
+      Array(compute_resource.bridges(node_id)).map do |b|
         h = b.respond_to?(:as_json) ? b.as_json : b
         {
           node_id: (h[:node_id] || h['node_id']),

--- a/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_vm_queries.rb
@@ -23,8 +23,14 @@ module ForemanFogProxmox
     include ProxmoxVMUuidHelper
 
     def nodes
-      nodes = client.nodes.all if client
-      nodes&.sort_by(&:node)
+      node_availability[:available]
+    end
+
+    def node_availability
+      inventory = client ? Array(client.nodes.all).sort_by(&:node) : []
+      available, offline = inventory.partition { |node| !offline_node?(node) }
+
+      { available: available, offline: offline }
     end
 
     def storages(node_id = default_node_id, type = 'images')
@@ -81,6 +87,10 @@ module ForemanFogProxmox
     end
 
     private
+
+    def offline_node?(node)
+      node.respond_to?(:status) && node.status == 'offline'
+    end
 
     def attach_compute_resource_id(virtual_machine)
       return virtual_machine if virtual_machine.nil?

--- a/test/functional/compute_resources_controller_test.rb
+++ b/test/functional/compute_resources_controller_test.rb
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>.
 require 'test_plugin_helper'
+require 'ostruct'
 
 module ForemanFogProxmox
   class ComputeResourcesControllerTest < ActionController::TestCase
@@ -29,13 +30,14 @@ module ForemanFogProxmox
       mock_storage.stubs(:volumes).returns([])
 
       @compute_resource.stubs(:images_by_storage).returns([])
-      @compute_resource.stubs(:nodes).returns([])
+      @available_node = OpenStruct.new(node: 'proxmox')
+      @compute_resource.stubs(:node_availability).returns(available: [@available_node], offline: [])
       @compute_resource.stubs(:pools).returns([])
       @compute_resource.stubs(:storages).with('proxmox').returns([mock_storage])
       @compute_resource.stubs(:storages).with('proxmox', 'vztmpl').returns([])
       @compute_resource.stubs(:storages).with('proxmox', 'iso').returns([])
       @compute_resource.stubs(:storages).with(nil).returns([])
-      @compute_resource.stubs(:bridges).returns([])
+      @compute_resource.stubs(:bridges).with('proxmox').returns([])
 
       # Stub ComputeResource.find to return our stubbed instance
       ComputeResource.stubs(:find).with(@compute_resource.id).returns(@compute_resource)
@@ -86,13 +88,46 @@ module ForemanFogProxmox
       json_response = JSON.parse(show_response)
       assert_instance_of Hash, json_response
       assert json_response.key?('nodes')
+      assert json_response.key?('offline_nodes')
       assert json_response.key?('pools')
       assert json_response.key?('storages')
       assert json_response.key?('bridges')
       assert_instance_of Array, json_response['nodes']
+      assert_instance_of Array, json_response['offline_nodes']
       assert_instance_of Array, json_response['pools']
       assert_instance_of Array, json_response['storages']
       assert_instance_of Array, json_response['bridges']
+    end
+
+    test 'metadata separates offline nodes from available nodes' do
+      offline_node = OpenStruct.new(node: 'offline-node')
+      @compute_resource.stubs(:node_availability).returns(
+        available: [@available_node],
+        offline: [offline_node]
+      )
+
+      get :metadata, params: { :compute_resource_id => @compute_resource.id }, session: set_session_user
+
+      assert_response :success
+      json_response = JSON.parse(@response.body)
+      assert_equal [{ 'node' => 'proxmox' }], json_response['nodes']
+      assert_equal ['offline-node'], json_response['offline_nodes']
+    end
+
+    test 'metadata skips node resources when all nodes are offline' do
+      offline_node = OpenStruct.new(node: 'offline-node')
+      @compute_resource.stubs(:node_availability).returns(available: [], offline: [offline_node])
+      @compute_resource.expects(:storages).never
+      @compute_resource.expects(:bridges).never
+
+      get :metadata, params: { :compute_resource_id => @compute_resource.id }, session: set_session_user
+
+      assert_response :success
+      json_response = JSON.parse(@response.body)
+      assert_empty json_response['nodes']
+      assert_equal ['offline-node'], json_response['offline_nodes']
+      assert_empty json_response['storages']
+      assert_empty json_response['bridges']
     end
   end
 end

--- a/test/unit/foreman_fog_proxmox/proxmox_vm_queries_test.rb
+++ b/test/unit/foreman_fog_proxmox/proxmox_vm_queries_test.rb
@@ -33,6 +33,51 @@ module ForemanFogProxmox
     include ProxmoxContainerMockFactory
     include ProxmoxVMHelper
 
+    describe 'nodes' do
+      before do
+        @cr = ForemanFogProxmox::Proxmox.new
+        @nodes = mock('nodes')
+        client = mock('client')
+        client.stubs(:nodes).returns(@nodes)
+        @cr.stubs(:client).returns(client)
+      end
+
+      it 'returns available nodes sorted by name' do
+        node_z = OpenStruct.new(node: 'node-z', status: 'online')
+        node_a = OpenStruct.new(node: 'node-a', status: 'online')
+        @nodes.stubs(:all).returns([node_z, node_a])
+
+        assert_equal %w[node-a node-z], @cr.nodes.map(&:node)
+      end
+
+      it 'excludes offline nodes' do
+        online = OpenStruct.new(node: 'online', status: 'online')
+        offline = OpenStruct.new(node: 'offline', status: 'offline')
+        @nodes.stubs(:all).returns([offline, online])
+
+        availability = @cr.node_availability
+
+        assert_equal [online], availability[:available]
+        assert_equal [offline], availability[:offline]
+        assert_equal [online], @cr.nodes
+      end
+
+      it 'keeps nodes without a status for compatibility' do
+        node = OpenStruct.new(node: 'unknown')
+        @nodes.stubs(:all).returns([node])
+
+        assert_equal [node], @cr.nodes
+      end
+
+      it 'returns an empty available list when all nodes are offline' do
+        offline = OpenStruct.new(node: 'offline', status: 'offline')
+        @nodes.stubs(:all).returns([offline])
+
+        assert_empty @cr.nodes
+        assert_equal [offline], @cr.node_availability[:offline]
+      end
+    end
+
     describe 'storages' do
       before do
         @cr = ForemanFogProxmox::Proxmox.new

--- a/webpack/components/ProxmoxVmType.js
+++ b/webpack/components/ProxmoxVmType.js
@@ -8,9 +8,10 @@ import {
   TabTitleText,
   Spinner,
   Bullseye,
+  Alert,
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
-import { translate as __ } from 'foremanReact/common/I18n';
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { API } from 'foremanReact/redux/API';
 import { ProxmoxBiosProvider } from './ProxmoxBiosContext';
 
@@ -53,6 +54,7 @@ const ProxmoxVmType = ({
   const [metaLoaded, setMetaLoaded] = useState(!!propsLoaded);
   const [metaError, setMetaError] = useState(false);
   const [metaNodes, setMetaNodes] = useState([]);
+  const [metaOfflineNodes, setMetaOfflineNodes] = useState([]);
   const [metaPools, setMetaPools] = useState([]);
   const [metaStorages, setMetaStorages] = useState([]);
   const [metaBridges, setMetaBridges] = useState([]);
@@ -109,6 +111,7 @@ const ProxmoxVmType = ({
         );
         if (!isMounted) return;
         setMetaNodes(data?.nodes || []);
+        setMetaOfflineNodes(data?.['offline_nodes'] || []);
         setMetaPools(data?.pools || []);
         setMetaStorages(data?.storages || []);
         setMetaBridges(data?.bridges || []);
@@ -331,6 +334,20 @@ const ProxmoxVmType = ({
               'Failed to load Proxmox metadata. Please check your compute resource connection.'
             )}
           </div>
+        )}
+
+        {metaOfflineNodes.length > 0 && (
+          <Alert
+            isInline
+            variant="warning"
+            title={sprintf(
+              __(
+                'The following Proxmox nodes are offline and unavailable: %(nodes)s'
+              ),
+              { nodes: metaOfflineNodes.join(', ') }
+            )}
+            style={{ marginTop: '8px' }}
+          />
         )}
 
         <Tabs

--- a/webpack/components/__tests__/ProxmoxVmType.test.js
+++ b/webpack/components/__tests__/ProxmoxVmType.test.js
@@ -1,14 +1,45 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { API } from 'foremanReact/redux/API';
 import ProxmoxVmType from '../ProxmoxVmType';
+
+jest.mock('foremanReact/redux/API', () => ({
+  API: {
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('foremanReact/common/I18n', () => ({
+  translate: value => value,
+  sprintf: (value, replacements) =>
+    value.replace('%(nodes)s', replacements.nodes),
+}));
+
+/* eslint-disable react/prop-types */
+jest.mock('@patternfly/react-core', () => {
+  const patternfly = jest.requireActual('@patternfly/react-core');
+
+  return {
+    ...patternfly,
+    Tabs: ({ children }) => <div>{children}</div>,
+    Tab: ({ children, title }) => (
+      <div>
+        {title}
+        {children}
+      </div>
+    ),
+  };
+});
+/* eslint-enable react/prop-types */
 
 jest.mock('../ProxmoxVmUtils', () => ({
   networkSelected: jest.fn(),
 }));
 
-jest.mock('../GeneralTabContent', () => () => (
+const mockGeneralTabContent = jest.fn(() => (
   <div data-testid="general-tab-content" />
 ));
+jest.mock('../GeneralTabContent', () => props => mockGeneralTabContent(props));
 
 jest.mock('../common/FormInputs', () => () => <div data-testid="type-field" />);
 
@@ -30,6 +61,11 @@ describe('ProxmoxVmType', () => {
     bridges: [],
   };
 
+  beforeEach(() => {
+    API.get.mockReset();
+    mockGeneralTabContent.mockClear();
+  });
+
   it('renders Type select and General tab', () => {
     render(<ProxmoxVmType {...baseProps} />);
 
@@ -50,5 +86,36 @@ describe('ProxmoxVmType', () => {
     const { container } = render(<ProxmoxVmType {...baseProps} registerComp />);
 
     expect(container.firstChild).toBeNull();
+  });
+
+  it('filters offline nodes and displays their names', async () => {
+    API.get.mockResolvedValue({
+      data: {
+        nodes: [{ node: 'online-node' }],
+        offline_nodes: ['offline-node'],
+        pools: [],
+        storages: [],
+        bridges: [],
+        images: [],
+      },
+    });
+
+    render(
+      <ProxmoxVmType {...baseProps} computeResourceId={1} propsLoaded={false} />
+    );
+
+    expect(
+      await screen.findByText(
+        'The following Proxmox nodes are offline and unavailable: offline-node'
+      )
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      const { calls } = mockGeneralTabContent.mock;
+      const [lastCall] = calls.slice(-1);
+      const [props] = lastCall;
+      expect(props.nodesMap).toEqual([
+        { value: 'online-node', label: 'online-node' },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
When one or more cluster nodes are offline, creating VMs or containers fails because it tries to load metadata from all nodes, including the unavailable one. This PR filters out unavailable nodes and queries the first available node for storage/network metadata, allowing creation to continue using the nodes that are online. It also displays a warning listing unavailable 
nodes.

This does not address the issue with nodes being in maintenance mode also mentioned in #368, because AFAICT that information is not gathered by fog-proxmox.

Prepared with some help from Copilot, particularly around the UI rendering and unit tests, so take with an appropriate grain of salt. Tested on Foreman 3.19.1 with my Proxmox cluster and confirmed that it can create VMs even when one node is down.